### PR TITLE
hello(world): initial action and CMakeLists

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+    "image" : "ghcr.io/uliegecsm/kokkos-utils/kokkos-utils:latest",
+    "extensions" : [
+        "ms-vscode.cmake-tools",
+        "mhutchie.git-graph",
+        "ms-azuretools.vscode-docker"
+    ],
+    "onCreateCommand": "git config --global --add safe.directory $PWD"
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+(Summarize the content of the PR concisely)
+
+## Description
+
+(A longer description of the PR)
+
+## Related to
+
+(A list of issues, PRs, links)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,124 @@
+name: Build
+
+on:
+    push:
+        branches:
+            - main
+            - develop
+    pull_request:
+        branches:
+            - main
+            - develop
+
+env:
+    REGISTRY: ghcr.io
+
+jobs:
+
+    set-vars:
+        runs-on: [ubuntu-latest]
+        outputs:
+            CI_IMAGE : ${{ steps.common.outputs.CI_IMAGE }}
+        steps:
+            - name: Export common variables.
+              id  : common
+              run : |
+                  echo "CI_IMAGE=${{ env.REGISTRY }}/${{ github.repository }}/kokkos-utils:latest" >> $GITHUB_OUTPUT
+
+    build-image:
+        needs: [set-vars]
+        runs-on: [ubuntu-latest]
+        container:
+            image: docker:latest
+        permissions:
+            packages: write
+        steps:
+            - name: Checkout code.
+              uses: actions/checkout@v4
+
+            - name: Login to GitHub Container Registry.
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build Docker image.
+              run : |
+                  apk add jq
+
+                  DOXYGEN_VERSION=$(jq .dependencies.doxygen.value version.json -j)
+                  GOOGLETEST_VERSION=$(jq .dependencies.googletest.value version.json -j)
+                  KOKKOS_VERSION=$(jq .dependencies.kokkos.value version.json -j)
+
+                  docker buildx build                                      \
+                      --pull                                               \
+                      --push                                               \
+                      --file dockerfile                                    \
+                      --platform linux/amd64                               \
+                      --tag ${{ needs.set-vars.outputs.CI_IMAGE }}         \
+                      --cache-from ${{ needs.set-vars.outputs.CI_IMAGE }}  \
+                      --build-arg BUILDKIT_INLINE_CACHE=1                  \
+                      --build-arg DOXYGEN_VERSION=${DOXYGEN_VERSION}       \
+                      --build-arg GOOGLETEST_VERSION=${GOOGLETEST_VERSION} \
+                      --build-arg KOKKOS_VERSION=${KOKKOS_VERSION}         \
+                      --build-arg KOKKOS_PRESET=OpenMP                     \
+                      --label "org.opencontainers.image.source=${{ github.repositoryUrl }}" \
+                      .
+
+    build-library:
+        needs: [set-vars, build-image]
+        runs-on: [ubuntu-latest]
+        container:
+            image: ${{ needs.set-vars.outputs.CI_IMAGE }}
+        steps:
+            - name: Checkout code.
+              uses: actions/checkout@v4
+
+            - name: Configure and build.
+              run : |
+                  cmake -S .    --preset=OpenMP
+                  cmake --build --preset=OpenMP
+
+    build-documentation:
+        needs: [set-vars, build-image]
+        runs-on: [ubuntu-latest]
+        container:
+            image: ${{ needs.set-vars.outputs.CI_IMAGE }}
+        steps:
+            - name: Checkout code.
+              uses: actions/checkout@v4
+
+            - name: Build Doxygen documentation.
+              run : |
+                  cmake -S . --preset=OpenMP
+                  cmake --build --preset=OpenMP --target=docs
+
+            - name: Upload Pages artifacts.
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  path: build-with-OpenMP/docs/html
+
+    # The deploy job is heavily inspired from https://github.com/actions/deploy-pages.
+    deploy:
+        # The deployment only happens if the library can be built and the documentation generated.
+        needs: [build-library, build-documentation]
+        runs-on: [ubuntu-latest]
+
+        # The deployment only happens for 'main' or 'develop' branch.
+        if: ${{ contains(fromJSON('["refs/heads/main", "refs/heads/develop"]'), github.ref) }}
+
+        # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+        permissions:
+            pages: write      # to deploy to Pages
+            id-token: write   # to verify the deployment originates from an appropriate source
+
+        # Deploy to the github-pages environment
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+
+        steps:
+            - name: Deploy to GitHub Pages.
+              id  : deployment
+              uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore CMake build directory
+build*/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.12)
+
+#---- Read the version file.
+file(READ version.json VERSION_JSON)
+
+string(JSON KOKKOS_UTILS_VERSION GET "${VERSION_JSON}" "kokkos-utils" "value")
+
+string(JSON DOXYGEN_VERSION      GET "${VERSION_JSON}" dependencies doxygen    value)
+string(JSON GOOGLETEST_VERSION   GET "${VERSION_JSON}" dependencies googletest value)
+string(JSON KOKKOS_VERSION       GET "${VERSION_JSON}" dependencies kokkos     value)
+
+#---- Define the project. It uses C++ only.
+project(
+    kokkos-utils
+    VERSION ${KOKKOS_UTILS_VERSION}
+    LANGUAGES CXX
+)
+
+#---- C++ standard that we need (at least).
+set(CMAKE_CXX_STANDARD          20   CACHE BOOL "" FORCE)
+set(CMAKE_CXX_STANDARD_REQUIRED True CACHE BOOL "" FORCE)
+
+#---- Find Kokkos.
+find_package(
+    Kokkos
+    ${KOKKOS_VERSION}
+    REQUIRED
+)
+
+#---- Find Google Test.
+find_package(
+    GTest
+    ${GOOGLETEST_VERSION}
+    CONFIG
+    REQUIRED
+)
+
+#---- Documentation.
+add_subdirectory(docs)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,23 @@
+{
+    "version"   : 3,
+    "configurePresets" : [
+        {
+            "name"          : "default",
+            "binaryDir"     : "${sourceDir}/build-with-${presetName}",
+            "cacheVariables" : {
+                "CMAKE_BUILD_TYPE"              : "Release",
+                "CMAKE_CXX_EXTENSIONS"          : "OFF"
+            }
+        },
+        {
+            "name"        : "OpenMP",
+            "inherits"    : "default"
+        }
+    ],
+    "buildPresets" : [
+        {
+            "name"            : "OpenMP",
+            "configurePreset" : "OpenMP"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # kokkos-utils
-This repository contains utilities related to `Kokkos`.
+
+This repository contains utilities related to [`Kokkos`](https://kokkos.org/).
+
+Our documentation is available [here](https://uliegecsm.github.io/kokkos-utils/).

--- a/cmake/presets/kokkos.json
+++ b/cmake/presets/kokkos.json
@@ -1,0 +1,28 @@
+{
+    "version"   : 3,
+    "configurePresets" : [
+        {
+            "name"          : "default",
+            "binaryDir"     : "${sourceDir}/build-with-${presetName}",
+            "cacheVariables" : {
+                "CMAKE_BUILD_TYPE"              : "Release",
+                "CMAKE_CXX_STANDARD"            : "17",
+                "CMAKE_CXX_EXTENSIONS"          : "OFF",
+                "BUILD_SHARED_LIBS"             : "ON"
+            }
+        },
+        {
+            "name"        : "OpenMP",
+            "inherits"    : "default",
+            "cacheVariables" : {
+                "Kokkos_ENABLE_OPENMP" : "ON"
+            }
+        }
+    ],
+    "buildPresets" : [
+        {
+            "name"            : "OpenMP",
+            "configurePreset" : "OpenMP"
+        }
+    ]
+}

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,100 @@
+FROM ubuntu:24.04 as apt-requirements
+
+# Install APT requirements.
+RUN --mount=target=/requirements,type=bind,source=requirements <<EOF
+
+    set -ex
+
+    apt update
+
+    apt --yes --no-install-recommends install $(grep -vE "^\s*#" /requirements/requirements.system.txt  | tr "\n" " ")
+
+    apt clean && rm -rf /var/lib/apt/lists/*
+
+EOF
+
+# Compile Doxygen.
+FROM apt-requirements as compile-doxygen
+
+ARG DOXYGEN_VERSION
+
+RUN <<EOF
+
+    set -ex
+
+    apt update
+
+    apt --yes --no-install-recommends install flex bison python3
+
+    git clone --depth=1 --branch Release_$(echo ${DOXYGEN_VERSION} | tr . _) https://github.com/doxygen/doxygen doxygen
+
+    cd doxygen
+
+    cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/opt/doxygen-${DOXYGEN_VERSION}
+
+    cmake --build build -j4
+
+    cmake --build build --target install
+
+EOF
+
+# Compile Google Test.
+FROM apt-requirements as compile-google-test
+
+ARG GOOGLETEST_VERSION
+
+RUN <<EOF
+
+    set -ex
+
+    git clone --depth=1 --branch=v${GOOGLETEST_VERSION} https://github.com/google/googletest googletest
+
+    cd googletest
+
+    cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/opt/google-test-${GOOGLETEST_VERSION}
+
+    cmake --build build -j4
+
+    cmake --build build --target install
+
+EOF
+
+# Compile Kokkos.
+FROM apt-requirements as compile-kokkos
+
+ARG KOKKOS_VERSION
+ARG KOKKOS_PRESET
+
+RUN --mount=target=/cmake/presets,type=bind,source=cmake/presets <<EOF
+
+    set -ex
+
+    git clone --depth=1 --branch=${KOKKOS_VERSION} https://github.com/kokkos/kokkos kokkos
+
+    cd kokkos
+
+    cp /cmake/presets/kokkos.json CMakePresets.json
+
+    cmake -S . --preset=${KOKKOS_PRESET} -DCMAKE_INSTALL_PREFIX=/opt/kokkos-${KOKKOS_VERSION}/${KOKKOS_PRESET}
+
+    cmake --build --preset=${KOKKOS_PRESET} -j4
+
+    cmake --build --preset=${KOKKOS_PRESET} --target=install
+
+EOF
+
+# Build the final image from previous stages.
+FROM apt-requirements as final
+
+ARG DOXYGEN_VERSION
+ARG GOOGLETEST_VERSION
+ARG KOKKOS_VERSION
+ARG KOKKOS_PRESET
+
+COPY --from=compile-doxygen     /opt/doxygen-${DOXYGEN_VERSION}                /opt/doxygen-${DOXYGEN_VERSION}
+COPY --from=compile-google-test /opt/google-test-${GOOGLETEST_VERSION}         /opt/google-test-${GOOGLETEST_VERSION}
+COPY --from=compile-kokkos      /opt/kokkos-${KOKKOS_VERSION}/${KOKKOS_PRESET} /opt/kokkos-${KOKKOS_VERSION}/${KOKKOS_PRESET}
+
+ENV Doxygen_ROOT=/opt/doxygen-${DOXYGEN_VERSION}
+ENV GTest_ROOT=/opt/google-test-${GOOGLETEST_VERSION}
+ENV Kokkos_ROOT=/opt/kokkos-${KOKKOS_VERSION}/${KOKKOS_PRESET}

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,0 +1,20 @@
+#--- Find Doxygen.
+find_package(
+    Doxygen
+    ${DOXYGEN_VERSION}
+    REQUIRED
+)
+
+#---- Our 'homepage' is the README file.
+set(HOMEPAGE_MD ${CMAKE_SOURCE_DIR}/README.md)
+
+#---- Doxygen settings.
+set(DOXYGEN_USE_MDFILE_AS_MAINPAGE ${HOMEPAGE_MD})
+
+#---- Add Doxygen as a target.
+#     See also https://cmake.org/cmake/help/latest/module/FindDoxygen.html.
+doxygen_add_docs(
+    docs
+
+    ${HOMEPAGE_MD}
+)

--- a/requirements/requirements.system.txt
+++ b/requirements/requirements.system.txt
@@ -1,0 +1,13 @@
+# Utilities
+wget
+
+# Source control
+ca-certificates
+git
+
+# Builders
+cmake
+make
+
+# Compilers
+g++

--- a/version.json
+++ b/version.json
@@ -1,0 +1,16 @@
+{
+    "kokkos-utils" : {
+        "value" : "0.0.1"
+    },
+    "dependencies" : {
+        "doxygen" : {
+            "value" : "1.10.0"
+        },
+        "googletest" : {
+            "value" : "1.14.0"
+        },
+        "kokkos" : {
+            "value" : "4.3.00"
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces:
- a `devcontainer.json`
- an action that builds a ready-to-use image (that is pushed on the `GitHub` container registry) with
   * `Google Test` 1.14.0 compiled, installed
   * `Kokkos` 4.3.00 compiled, installed (with `OpenMP` backend) 