### PR TITLE
Better doxygen + allow GPG sharing with host while inside `devcontainer`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image" : "ghcr.io/uliegecsm/kokkos-utils/kokkos-utils:latest",
+    "dockerFile": "dockerfile",
     "extensions" : [
         "ms-vscode.cmake-tools",
         "mhutchie.git-graph",

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -1,0 +1,16 @@
+FROM ghcr.io/uliegecsm/kokkos-utils/kokkos-utils:latest
+
+# Install gpg and gnupg2 allows the container to use GPG keys to sign commits.
+# See also:
+#   - https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials
+RUN <<EOF
+
+    set -ex
+
+    apt update
+
+    apt --yes --no-install-recommends install gpg gnupg2
+
+    apt clean && rm -rf /var/lib/apt/lists/*
+
+EOF

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -10,6 +10,9 @@ set(HOMEPAGE_MD ${CMAKE_SOURCE_DIR}/README.md)
 
 #---- Doxygen settings.
 set(DOXYGEN_USE_MDFILE_AS_MAINPAGE ${HOMEPAGE_MD})
+set(DOXYGEN_HTML_TIMESTAMP YES)
+set(DOXYGEN_WARN_AS_ERROR YES)
+set(DOXYGEN_SOURCE_BROWSER YES)
 
 #---- Add Doxygen as a target.
 #     See also https://cmake.org/cmake/help/latest/module/FindDoxygen.html.


### PR DESCRIPTION
## Summary

This PR:
1. Adds useful options to `Doxygen`.
2. Changes a bit the `devcontainer` logic to allow for local GPG keys to be shared within the container, thus allowing GPG signed commits.
