### PR TITLE
Use multiplatform approach to build for amd64 and arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,20 @@ jobs:
             - name: Checkout code.
               uses: actions/checkout@v4
 
+            - name: Prepare.
+              run: |
+                  apk add jq
+
+                  echo "DOXYGEN_VERSION=$(jq .dependencies.doxygen.value version.json -j)" >> $GITHUB_ENV
+                  echo "GOOGLETEST_VERSION=$(jq .dependencies.googletest.value version.json -j)" >> $GITHUB_ENV
+                  echo "KOKKOS_VERSION=$(jq .dependencies.kokkos.value version.json -j)" >> $GITHUB_ENV
+
+            - name: Set up QEMU.
+              uses: docker/setup-qemu-action@v3
+
+            - name: Set up Docker Buildx.
+              uses: docker/setup-buildx-action@v3
+
             - name: Login to GitHub Container Registry.
               uses: docker/login-action@v3
               with:
@@ -43,28 +57,22 @@ jobs:
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Build Docker image.
-              run : |
-                  apk add jq
-
-                  DOXYGEN_VERSION=$(jq .dependencies.doxygen.value version.json -j)
-                  GOOGLETEST_VERSION=$(jq .dependencies.googletest.value version.json -j)
-                  KOKKOS_VERSION=$(jq .dependencies.kokkos.value version.json -j)
-
-                  docker buildx build                                      \
-                      --pull                                               \
-                      --push                                               \
-                      --file dockerfile                                    \
-                      --platform linux/amd64                               \
-                      --tag ${{ needs.set-vars.outputs.CI_IMAGE }}         \
-                      --cache-from ${{ needs.set-vars.outputs.CI_IMAGE }}  \
-                      --build-arg BUILDKIT_INLINE_CACHE=1                  \
-                      --build-arg DOXYGEN_VERSION=${DOXYGEN_VERSION}       \
-                      --build-arg GOOGLETEST_VERSION=${GOOGLETEST_VERSION} \
-                      --build-arg KOKKOS_VERSION=${KOKKOS_VERSION}         \
-                      --build-arg KOKKOS_PRESET=OpenMP                     \
-                      --label "org.opencontainers.image.source=${{ github.repositoryUrl }}" \
-                      .
+            - name: Build and push.
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  platforms: linux/amd64,linux/arm64
+                  push: ${{ github.ref == 'refs/heads/develop' }}
+                  file: dockerfile
+                  tags: ${{ needs.set-vars.outputs.CI_IMAGE }}
+                  cache-from: type=registry,ref=${{ needs.set-vars.outputs.CI_IMAGE }}
+                  cache-to: type=inline
+                  build-args: |
+                      DOXYGEN_VERSION=${{ env.DOXYGEN_VERSION }}
+                      GOOGLETEST_VERSION=${{ env.GOOGLETEST_VERSION }}
+                      KOKKOS_VERSION=${{ env.KOKKOS_VERSION }}
+                      KOKKOS_PRESET=OpenMP
+                  labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 
     build-library:
         needs: [set-vars, build-image]


### PR DESCRIPTION
## Summary

This PR changes the `build-image` job so that a multiplatform image amd64/arm64 is built.

## Description

The goal is to ease development on Mac.

[Edit]

The multi platform approach is based on:
- https://docs.docker.com/build/ci/github-actions/multi-platform/

This is a link for cache management (if we should see it doesn't cache, but it seemed in previous single-platform builds):
- https://docs.docker.com/build/ci/github-actions/cache/
