### PR TITLE
atomics: insert op with atomic min

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(Kokkos::utils ALIAS KokkosUtils)
 target_sources(
     KokkosUtils
     INTERFACE
+        include/kokkos-utils/atomics/InsertOp.hpp
         include/kokkos-utils/concepts/View.hpp
 )
 

--- a/include/kokkos-utils/atomics/InsertOp.hpp
+++ b/include/kokkos-utils/atomics/InsertOp.hpp
@@ -1,0 +1,27 @@
+#ifndef KOKKOS_UTILS_ATOMICS_INSERTOP_HPP
+#define KOKKOS_UTILS_ATOMICS_INSERTOP_HPP
+
+#include <concepts>
+
+#include "kokkos-utils/concepts/View.hpp"
+
+namespace Kokkos::utils::atomics
+{
+
+/**
+ * @brief Insert an element in a view at a specific index using @c Kokkos::atomic_min.
+ *
+ * To be used with *e.g.* @c Kokkos::UnorderedMap::insert.
+ */
+struct InsertMin
+{
+    template <concepts::View ViewType, std::integral IndexType, typename ValueType>
+    KOKKOS_FUNCTION
+    void op(const ViewType& values, const IndexType index, ValueType&& value) const {
+        Kokkos::atomic_min(&values(index), std::forward<ValueType>(value));
+    }
+};
+
+} // namespace Kokkos::utils::atomics
+
+#endif // KOKKOS_UTILS_ATOMICS_INSERTOP_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,13 +38,21 @@ function(add_one_test)
             ${SOURCE_FILE}
     )
 
+    # Compile options.
+    target_compile_options(
+        ${EXECUTABLE_NAME}
+        PRIVATE
+            -Wall
+            -Wextra
+            -Werror
+    )
+
     # Link the executable to the library, GTest and Kokkos.
     target_link_libraries(
         ${EXECUTABLE_NAME}
         PRIVATE
             Kokkos::utils
-            GTest::gtest_main
-            Kokkos::kokkoscore
+            test_common
     )
 
     # Add the test to CTest.
@@ -54,6 +62,23 @@ function(add_one_test)
     )
 
 endfunction()
+
+# Common test library (object-like) which each test links to.
+add_library(test_common OBJECT)
+target_sources(
+    test_common
+    PRIVATE
+        main.cpp
+)
+target_link_libraries(
+    test_common
+    PUBLIC
+        GTest::gtest
+        Kokkos::kokkoscore
+)
+
+### TESTS : atomics ###
+add_subdirectory(atomics)
 
 ### TESTS : concepts ###
 add_subdirectory(concepts)

--- a/tests/atomics/CMakeLists.txt
+++ b/tests/atomics/CMakeLists.txt
@@ -1,0 +1,4 @@
+### TEST : InsertOp ###
+add_one_test(
+    TEST_NAME InsertOp
+)

--- a/tests/atomics/test_InsertOp.cpp
+++ b/tests/atomics/test_InsertOp.cpp
@@ -1,0 +1,52 @@
+#include "gtest/gtest.h"
+
+#include "Kokkos_Core.hpp"
+
+#include "kokkos-utils/atomics/InsertOp.hpp"
+
+using execution_space = Kokkos::DefaultExecutionSpace;
+
+/**
+ * @file
+ *
+ * @addtogroup unittests
+ *
+ * **Atomic insertion**
+ *
+ * This group of tests check the behavior of our atomic insert operators.
+ */
+
+namespace Kokkos::utils::tests::atomics
+{
+
+//! @test Check that @ref Kokkos::utils::atomics::InsertMin works as expected.
+TEST(atomics, InsertMin)
+{
+    using view_t = Kokkos::View<int*, execution_space>;
+
+    constexpr int trials = 150;
+
+    const execution_space space {};
+
+    const view_t data(Kokkos::view_alloc(space, "data"), 2);
+
+    const utils::atomics::InsertMin insert_min {};
+
+    Kokkos::parallel_for(
+        "atomics::InsertMin",
+        Kokkos::RangePolicy<execution_space>(space, 0, trials),
+        KOKKOS_LAMBDA(const int trial)
+        {
+            insert_min.op(data, 0, trials - trial - 2);
+            insert_min.op(data, 1, 2);
+        }
+    );
+    space.fence();
+
+    const auto mirror = Kokkos::create_mirror_view_and_copy(Kokkos::DefaultHostExecutionSpace{}, data);
+
+    ASSERT_EQ(mirror(0), -1);
+    ASSERT_EQ(mirror(1),  0);
+}
+
+} // namespace Kokkos::utils::tests::atomics

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,17 @@
+#include "gtest/gtest.h"
+
+#include "Kokkos_Core.hpp"
+
+//! Initialize Google Test and @c Kokkos.
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    Kokkos::initialize(argc, argv);
+
+    const auto result = RUN_ALL_TESTS();
+
+    Kokkos::finalize();
+
+    return result;
+}


### PR DESCRIPTION
## Summary

This PR introduces the `atomics` namespace.

In this namespace, we now have `InsertOp.hpp`, a collection of helpers for inserting atomically.

In this `InsertOp.hpp`, we now have `InsertMin`, that can insert an element at a given index in a view, using `Kokkos::atomic_min`. It might be used with `Kokkos::UnorderedMap::insert` for instance.

## Description

Since the test `test_InsertOp.cpp` needs to allocate `Kokkos::View`s, we need to initialize `Kokkos`. Therefore, I introduced an object library with a `main.cpp` that initializes both `Google Test` and `Kokkos`.