### PR TITLE
cicd: add schedule to cope for updated base image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
         branches:
             - main
             - develop
+    schedule:
+        # As advised by https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule,
+        # let's start the scheduled action at a somewhat random time to avoid periods of high load.
+        - cron: '42 5 * * 3'
 
 env:
     REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

This PR introduces a scheduled action.

I followed best practice and set the *cron* start at end of night, and not at the start of an hour to avoid high load times of GitHub runners.

This schedule will basically do not much if our base images from `Docker` hub haven't changed.
