### PR TITLE
concepts(containers): add concept for `Kokkos::DualView`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ target_sources(
     KokkosUtils
     INTERFACE
         include/kokkos-utils/atomics/InsertOp.hpp
+
+        include/kokkos-utils/concepts/DualView.hpp
         include/kokkos-utils/concepts/View.hpp
 )
 

--- a/include/kokkos-utils/concepts/DualView.hpp
+++ b/include/kokkos-utils/concepts/DualView.hpp
@@ -1,0 +1,15 @@
+#ifndef KOKKOS_UTILS_CONCEPTS_DUALVIEW_HPP
+#define KOKKOS_UTILS_CONCEPTS_DUALVIEW_HPP
+
+#include "Kokkos_DualView.hpp"
+
+namespace Kokkos::utils::concepts
+{
+
+//! Concept to specify that a type is a @c Kokkos::DualView.
+template <typename T>
+concept DualView = Kokkos::is_dual_view_v<T>;
+
+} // namespace Kokkos::utils::concepts
+
+#endif // KOKKOS_UTILS_CONCEPTS_DUALVIEW_HPP

--- a/tests/concepts/CMakeLists.txt
+++ b/tests/concepts/CMakeLists.txt
@@ -1,3 +1,8 @@
+### TEST : DualView ###
+add_one_test(
+    TEST_NAME DualView
+)
+
 ### TEST : View ###
 add_one_test(
     TEST_NAME View

--- a/tests/concepts/test_DualView.cpp
+++ b/tests/concepts/test_DualView.cpp
@@ -1,0 +1,42 @@
+#include "gtest/gtest.h"
+
+#include "kokkos-utils/concepts/DualView.hpp"
+#include "kokkos-utils/concepts/View.hpp"
+
+using execution_space = Kokkos::DefaultExecutionSpace;
+
+/**
+ * @file
+ *
+ * @addtogroup unittests
+ *
+ * **Concepts related to @c Kokkos::DualView**
+ *
+ * This group of tests check the behavior of our concepts related to @c Kokkos::DualView.
+ */
+
+namespace Kokkos::utils::tests::concepts
+{
+
+//! @test Check that @ref Kokkos::utils::concepts::DualView works as expected.
+TEST(concepts, DualView)
+{
+    using dual_view_1d_t = Kokkos::DualView<int[5]   , execution_space>;
+    using      view_1d_t = Kokkos::    View<int[5]   , execution_space>;
+    using dual_view_2d_t = Kokkos::DualView<int[5][5], execution_space>;
+    using      view_2d_t = Kokkos::    View<int[5][5], execution_space>;
+
+    //! A @c Kokkos::DualView fulfills the concept.
+    static_assert(Kokkos::utils::concepts::DualView<dual_view_1d_t>);
+    static_assert(Kokkos::utils::concepts::DualView<dual_view_2d_t>);
+
+    //! A @c Kokkos::View does not fulfill the concept.
+    static_assert(! Kokkos::utils::concepts::DualView<view_1d_t>);
+    static_assert(! Kokkos::utils::concepts::DualView<view_2d_t>);
+
+    //! A @c Kokkos::DualView does not fulfill the @ref Kokkos::utils::concepts::View concept.
+    static_assert(! Kokkos::utils::concepts::View<dual_view_1d_t>);
+    static_assert(! Kokkos::utils::concepts::View<dual_view_2d_t>);
+}
+
+} // namespace Kokkos::utils::tests::concepts


### PR DESCRIPTION
## Summary

This PR adds the `Kokkos::utils::concepts::DualView` concept.

