### PR TITLE
View extents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ add_library(Kokkos::utils ALIAS KokkosUtils)
 target_sources(
     KokkosUtils
     INTERFACE
+        include/kokkos-utils/array/compare.hpp
+
         include/kokkos-utils/atomics/InsertOp.hpp
 
         include/kokkos-utils/concepts/DualView.hpp
@@ -62,6 +64,8 @@ target_sources(
         include/kokkos-utils/concepts/View.hpp
 
         include/kokkos-utils/impl/type_traits.hpp
+
+        include/kokkos-utils/view/extents.hpp
 )
 
 target_include_directories(

--- a/include/kokkos-utils/array/compare.hpp
+++ b/include/kokkos-utils/array/compare.hpp
@@ -1,0 +1,47 @@
+#ifndef KOKKOS_UTILS_ARRAY_COMPARE_HPP
+#define KOKKOS_UTILS_ARRAY_COMPARE_HPP
+
+#include "Kokkos_Array.hpp"
+
+/**
+ * @file
+ *
+ * This file defines @c operator== for @c Kokkos::Array in the <tt>namespace Kokkos</tt>.
+ *
+ * This file can disappear when either https://github.com/kokkos/kokkos/pull/6599 or
+ * https://github.com/kokkos/kokkos/pull/7148 is merged.
+ */
+
+namespace Kokkos
+{
+    //! Operator== for @c Kokkos::Array.
+    template <
+        typename LT, size_t LN, typename LP,
+        typename RT, size_t RN, typename RP
+    >
+    KOKKOS_INLINE_FUNCTION constexpr bool operator==(
+        const Array<LT, LN, LP>& lhs,
+        const Array<RT, RN, RP>& rhs
+    ) {
+        if (lhs.size() != rhs.size()) return false;
+        for (size_t i = 0; i < lhs.size(); ++i) {
+            if (lhs[i] != rhs[i]) return false;
+        }
+        return true;
+    }
+
+    //! Operator!= for @c Kokkos::Array.
+    template <
+        typename LT, size_t LN, typename LP,
+        typename RT, size_t RN, typename RP
+    >
+    KOKKOS_INLINE_FUNCTION constexpr bool operator!=(
+        const Array<LT, LN, LP>& lhs,
+        const Array<RT, RN, RP>& rhs
+    ) {
+        return !(lhs == rhs);
+    }
+
+} // namespace Kokkos
+
+#endif // KOKKOS_UTILS_ARRAY_COMPARE_HPP

--- a/include/kokkos-utils/atomics/InsertOp.hpp
+++ b/include/kokkos-utils/atomics/InsertOp.hpp
@@ -11,7 +11,7 @@ namespace Kokkos::utils::atomics
 /**
  * @brief Insert an element in a view at a specific index using @c Kokkos::atomic_min.
  *
- * To be used with *e.g.* @ref Kokkos::UnorderedMap::insert.
+ * To be used with *e.g.* @c Kokkos::UnorderedMap::insert.
  */
 struct InsertMin
 {

--- a/include/kokkos-utils/concepts/View.hpp
+++ b/include/kokkos-utils/concepts/View.hpp
@@ -10,23 +10,23 @@
 namespace Kokkos::utils::concepts
 {
 
-//! Specify that a type is a @ref Kokkos::View.
+//! Specify that a type is a @c Kokkos::View.
 template <typename T>
 concept View = Kokkos::is_view_v<T>;
 
-//! Specify that a type is a @ref Kokkos::View of given rank @p Rank.
+//! Specify that a type is a @c Kokkos::View of given rank @p Rank.
 template <typename T, std::size_t Rank>
 concept ViewOfRank = View<T> && T::rank == Rank;
 
-//! Specify that a type is a modifiable @ref Kokkos::View.
+//! Specify that a type is a modifiable @c Kokkos::View.
 template <typename T>
 concept ModifiableView = View<T> && ! std::is_const_v<typename T::value_type>;
 
-//! Specify that a type is a @ref Kokkos::View with value type @p ValueType.
+//! Specify that a type is a @c Kokkos::View with value type @p ValueType.
 template <typename T, typename ValueType>
 concept ViewOf = View<T> && std::same_as<typename T::value_type, ValueType>;
 
-//! Specify that a type is a @ref Kokkos::View, whose value type is an instance of a given class template @p U.
+//! Specify that a type is a @c Kokkos::View, whose value type is an instance of a given class template @p U.
 template <typename T, template <typename...> class U>
 concept ViewOfInstanceOf = View<T> && impl::InstanceOf<typename T::value_type, U>;
 

--- a/include/kokkos-utils/view/extents.hpp
+++ b/include/kokkos-utils/view/extents.hpp
@@ -1,0 +1,43 @@
+#ifndef KOKKOS_UTILS_VIEW_EXTENTS_HPP
+#define KOKKOS_UTILS_VIEW_EXTENTS_HPP
+
+#include "kokkos-utils/concepts/View.hpp"
+
+/**
+ * @file
+ *
+ * This file is a collection of helper functions similar to what can be found in
+ * the standard @c mdspan header, related to retrieving the extents of a @c Kokkos::View.
+ */
+
+namespace Kokkos::utils::view
+{
+
+namespace impl
+{
+
+//! Implementation of @ref Kokkos::utils::view::extents.
+template <concepts::View ViewType, size_t... Ints>
+KOKKOS_INLINE_FUNCTION
+constexpr auto extents(const ViewType& view, std::index_sequence<Ints...>)
+{
+    Kokkos::Array<size_t, sizeof...(Ints)> extents {};
+    ((extents[Ints] = view.extent(Ints)), ...);
+    return extents;
+}
+
+} // namespace impl
+
+//! Get all extents of @p view.
+template <concepts::View ViewType>
+KOKKOS_INLINE_FUNCTION
+constexpr auto extents(const ViewType& view)
+{
+    constexpr auto rank = ViewType::rank;
+    constexpr auto dims = std::make_index_sequence<rank>{};
+    return impl::extents(view, dims);
+}
+
+} // namespace Kokkos::utils::view
+
+#endif // KOKKOS_UTILS_VIEW_EXTENTS_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,3 +85,6 @@ add_subdirectory(concepts)
 
 ### TESTS : impl ###
 add_subdirectory(impl)
+
+### TESTS : view ###
+add_subdirectory(view)

--- a/tests/concepts/test_DualView.cpp
+++ b/tests/concepts/test_DualView.cpp
@@ -33,7 +33,7 @@ TEST(concepts, DualView)
     static_assert(DualView<dual_view_1d_t>);
     static_assert(DualView<dual_view_2d_t>);
 
-    //! A @ref Kokkos::View does not fulfill the concept.
+    //! A @c Kokkos::View does not fulfill the concept.
     static_assert(! DualView<view_1d_t>);
     static_assert(! DualView<view_2d_t>);
 

--- a/tests/concepts/test_View.cpp
+++ b/tests/concepts/test_View.cpp
@@ -13,9 +13,9 @@ using execution_space = Kokkos::DefaultExecutionSpace;
  *
  * @addtogroup unittests
  *
- * **Concepts related to @ref Kokkos::View**
+ * **Concepts related to @c Kokkos::View**
  *
- * This group of tests check the behavior of our concepts related to @ref Kokkos::View.
+ * This group of tests check the behavior of our concepts related to @c Kokkos::View.
  */
 
 namespace Kokkos::utils::tests::concepts

--- a/tests/view/CMakeLists.txt
+++ b/tests/view/CMakeLists.txt
@@ -1,0 +1,4 @@
+### TEST : extents ###
+add_one_test(
+    TEST_NAME extents
+)

--- a/tests/view/test_extents.cpp
+++ b/tests/view/test_extents.cpp
@@ -1,0 +1,69 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "Kokkos_Core.hpp"
+
+#include "kokkos-utils/array/compare.hpp"
+#include "kokkos-utils/view/extents.hpp"
+
+using execution_space = Kokkos::DefaultExecutionSpace;
+
+/**
+ * @file
+ *
+ * @addtogroup unittests
+ *
+ * **Get extents of a @c Kokkos::View**
+ *
+ * This group of tests check the behavior of our helpers related to @c Kokkos::View that can be
+ * found in @ref extents.hpp.
+ */
+
+namespace Kokkos::utils::tests::view
+{
+
+constexpr size_t dim_1 = 5, dim_2 = 3, dim_3 = 6, dim_4 = 9;
+
+//! @test Check that @ref view::extents works as expected for a rank-1 @c Kokkos::View.
+TEST(view, extents_rank_1)
+{
+    const Kokkos::View<double[dim_1], execution_space> view_1_static("rank-1 view with static extent");
+    const Kokkos::View<double*      , execution_space> view_1_dynami("rank-1 view with dynamic extent", dim_1);
+
+    ASSERT_EQ(utils::view::extents(view_1_static), Kokkos::Array{dim_1});
+    ASSERT_EQ(utils::view::extents(view_1_dynami), Kokkos::Array{dim_1});
+}
+
+//! @test Check that @ref view::extents works as expected for a rank-2 @c Kokkos::View.
+TEST(view, extents_rank_2)
+{
+    const Kokkos::View<double[dim_1][dim_2], execution_space> view_2_static("rank-2 view with static extents");
+    const Kokkos::View<double**            , execution_space> view_2_dynami("rank-2 view with dynamic extents", dim_1, dim_2);
+    const Kokkos::View<double*[dim_2]      , execution_space> view_2_mixed ("rank-2 view with mixed extents"  , dim_1);
+
+    ASSERT_EQ(utils::view::extents(view_2_static), (Kokkos::Array{dim_1, dim_2}));
+    ASSERT_EQ(utils::view::extents(view_2_dynami), (Kokkos::Array{dim_1, dim_2}));
+    ASSERT_EQ(utils::view::extents(view_2_mixed ), (Kokkos::Array{dim_1, dim_2}));
+}
+
+//! @test Check that @ref view::extents works as expected for a rank-3 @c Kokkos::View.
+TEST(view, extents_rank_3)
+{
+    const Kokkos::View<double[dim_1][dim_2][dim_3], execution_space> view_3_static("rank-3 view of static extents");
+    const Kokkos::View<double***                  , execution_space> view_3_dynami("rank-3 view of dynamic extents", dim_1, dim_2, dim_3);
+    const Kokkos::View<double*[dim_2][dim_3]      , execution_space> view_3_mixed ("rank-3 view of mixed extents"  , dim_1);
+
+    ASSERT_EQ(utils::view::extents(view_3_static), (Kokkos::Array{dim_1, dim_2, dim_3}));
+    ASSERT_EQ(utils::view::extents(view_3_dynami), (Kokkos::Array{dim_1, dim_2, dim_3}));
+    ASSERT_EQ(utils::view::extents(view_3_mixed ), (Kokkos::Array{dim_1, dim_2, dim_3}));
+}
+
+//! @test Check that @ref view::extents works as expected for a rank-4 @c Kokkos::View.
+TEST(view, extents_rank_4)
+{
+    const Kokkos::View<double[dim_1][dim_2][dim_3][dim_4], execution_space> view_4_static("rank-4 view of static extents");
+
+    ASSERT_EQ(utils::view::extents(view_4_static), (Kokkos::Array{dim_1, dim_2, dim_3, dim_4}));
+}
+
+} // namespace Kokkos::utils::tests::view


### PR DESCRIPTION
## Summary

This PR brings the `Kokkos::utils::view::extents` feature, that works as `std::extents` for `std::mdspan`.

