### PR TITLE
cmake(tests): rename `TEST_NAME` to `NAME`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,15 +14,15 @@ function(add_one_test)
     cmake_parse_arguments(
         aot_args
         ""
-        "TEST_NAME"
+        "NAME"
         ""
         ${ARGN}
     )
 
     # Set the test name, executable name and primary source file.
-    set(TEST_NAME       "test_${aot_args_TEST_NAME}")
-    set(EXECUTABLE_NAME "test_${aot_args_TEST_NAME}")
-    cmake_path(SET SOURCE_FILE "test_${aot_args_TEST_NAME}.cpp")
+    set(NAME            "test_${aot_args_NAME}")
+    set(EXECUTABLE_NAME "test_${aot_args_NAME}")
+    cmake_path(SET SOURCE_FILE "test_${aot_args_NAME}.cpp")
     cmake_path(ABSOLUTE_PATH SOURCE_FILE)
 
     # Add source file to the documentation list.

--- a/tests/atomics/CMakeLists.txt
+++ b/tests/atomics/CMakeLists.txt
@@ -1,4 +1,2 @@
 ### TEST : InsertOp ###
-add_one_test(
-    TEST_NAME InsertOp
-)
+add_one_test(NAME InsertOp)

--- a/tests/concepts/CMakeLists.txt
+++ b/tests/concepts/CMakeLists.txt
@@ -1,24 +1,14 @@
 ### TEST : DualView ###
-add_one_test(
-    TEST_NAME DualView
-)
+add_one_test(NAME DualView)
 
 ### TEST : ExecutionSpace ###
-add_one_test(
-    TEST_NAME ExecutionSpace
-)
+add_one_test(NAME ExecutionSpace)
 
 ### TEST : MemorySpace ###
-add_one_test(
-    TEST_NAME MemorySpace
-)
+add_one_test(NAME MemorySpace)
 
 ### TEST : Space ###
-add_one_test(
-    TEST_NAME Space
-)
+add_one_test(NAME Space)
 
 ### TEST : View ###
-add_one_test(
-    TEST_NAME View
-)
+add_one_test(NAME View)

--- a/tests/impl/CMakeLists.txt
+++ b/tests/impl/CMakeLists.txt
@@ -1,9 +1,5 @@
 ### TEST : type_list ###
-add_one_test(
-    TEST_NAME type_list
-)
+add_one_test(NAME type_list)
 
 ### TEST : type_traits ###
-add_one_test(
-    TEST_NAME type_traits
-)
+add_one_test(NAME type_traits)

--- a/tests/view/CMakeLists.txt
+++ b/tests/view/CMakeLists.txt
@@ -1,4 +1,2 @@
 ### TEST : extents ###
-add_one_test(
-    TEST_NAME extents
-)
+add_one_test(NAME extents)


### PR DESCRIPTION
## Summary

Very small PR to rename the `TEST_NAME` argument of `add_one_test` to `NAME`, for consistency with `CMake`'s `add_test`.
