### PR TITLE
docker(fix): clean apt to reduce image cache size

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -64,6 +64,8 @@ RUN <<EOF
 
     cmake --build build --target install
 
+    apt clean && rm -rf /var/lib/apt/lists/*
+
 EOF
 
 # Compile Google Test.


### PR DESCRIPTION
## Summary

Even though the layer is not included into the final one, we're still relying on caching. This PR adds a small cleanup step in the `doxygen` stage to reduce (hopefully) the cache size.
