### PR TITLE
cmake(bug): kokkos-utils target must depend on kokkos core target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,12 @@ target_compile_definitions(
         KOKKOS_IMPL_PUBLIC_INCLUDE
 )
 
+target_link_libraries(
+    KokkosUtils
+    INTERFACE
+        Kokkos::kokkoscore
+)
+
 #---- Testing.
 if(KokkosUtils_ENABLE_TESTS)
     enable_testing()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,9 +72,10 @@ target_sources(
 )
 target_link_libraries(
     test_common
+    PRIVATE
+        Kokkos::kokkoscore
     PUBLIC
         GTest::gtest
-        Kokkos::kokkoscore
 )
 
 ### TESTS : atomics ###


### PR DESCRIPTION
## Summary

The `KokkosUtils` target *must* depend on `Kokkos::kokkoscore`. Otherwise, the `CMake` dependency tree is not correct.
