### PR TITLE
Add `type_list_index_v`

### DIFF
--- a/include/kokkos-utils/impl/type_list.hpp
+++ b/include/kokkos-utils/impl/type_list.hpp
@@ -85,6 +85,23 @@ template <typename T>
 using type_list_to_tuple_t = typename TypeListToTuple<T>::type;
 ///@}
 
+//! @name Get the index of a type in a @c Kokkos::Impl::type_list.
+///@{
+template <typename, typename>
+struct TypeListIndex;
+
+template <typename T, typename... Ts>
+struct TypeListIndex<T, Kokkos::Impl::type_list<T, Ts...>>
+  : std::integral_constant<size_t, 0> {};
+
+template <typename T, typename Head, typename... Ts>
+struct TypeListIndex<T, Kokkos::Impl::type_list<Head, Ts...>>
+  : std::integral_constant<size_t, 1 + TypeListIndex<T, Kokkos::Impl::type_list<Ts...>>::value> {};
+
+template <typename T, typename S>
+inline constexpr size_t type_list_index_v = TypeListIndex<T, S>::value;
+///@}
+
 } // namespace Kokkos::utils::impl
 
 #endif // KOKKOS_UTILS_IMPL_TYPE_LIST_HPP

--- a/tests/impl/test_type_list.cpp
+++ b/tests/impl/test_type_list.cpp
@@ -76,4 +76,14 @@ TEST(impl, type_list_to_tuple)
     static_assert(std::same_as<type_list_to_tuple_t<type_list_t>, expt_tuple_t>);
 }
 
+//! @test Check @ref Kokkos::utils::impl::type_list_index_v.
+TEST(impl, type_list_index_v)
+{
+    using Kokkos::utils::impl::type_list_index_v;
+
+    static_assert(type_list_index_v<char,  type_list_t> == 0);
+    static_assert(type_list_index_v<short, type_list_t> == 1);
+    static_assert(type_list_index_v<int,   type_list_t> == 2);
+}
+
 } // namespace Kokkos::utils::tests::impl


### PR DESCRIPTION
## Summary

This PR adds a helper to find the index of a type in a `Kokkos::Impl::type_list`.
