### PR TITLE
cicd(docker): update to `Ubuntu 24.04`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
                 include:
                     - backend        : Cuda
                       compiler_family: nvidia
-                      base_image     : nvidia/cuda:12.6.2-devel-ubuntu24.04
+                      base_image     : nvidia/cuda:12.6.3-devel-ubuntu24.04
                       platforms      : linux/amd64
                       kokkos_arch    : VOLTA70
                     - backend        : OpenMP

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
                 include:
                     - backend        : Cuda
                       compiler_family: nvidia
-                      base_image     : nvidia/cuda:12.6.0-devel-ubuntu22.04
+                      base_image     : nvidia/cuda:12.6.2-devel-ubuntu24.04
                       platforms      : linux/amd64
                       kokkos_arch    : VOLTA70
                     - backend        : OpenMP


### PR DESCRIPTION
## Summary

This PR updates our `Docker` images to use `Ubuntu 24.04`.
