### PR TITLE
cicd: enable clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,84 @@
+---
+# This is the list of checks that we want to enable.
+# We only enable the checks that we want to tackle. This is done by first disabling all checks
+# with '*-', and then listing any check we want.
+#
+# See also https://clang.llvm.org/extra/clang-tidy/ for a description of 'clang-tidy'.
+# See also https://clang.llvm.org/extra/clang-tidy/checks/list.html for a complete list of supported checks.
+Checks:
+    '
+    -*,
+    bugprone-copy-constructor-init,
+    bugprone-fold-init-type,
+    bugprone-incorrect-enable-if,
+    bugprone-parent-virtual-call,
+    bugprone-reserved-identifier,
+    bugprone-string-constructor,
+    bugprone-suspicious-semicolon,
+    bugprone-suspicious-string-compare,
+    bugprone-too-small-loop-variable,
+    bugprone-undelegated-constructor,
+    bugprone-use-after-move,
+    cppcoreguidelines-missing-std-forward,
+    cppcoreguidelines-prefer-member-initializer,
+    cppcoreguidelines-pro-type-member-init,
+    cppcoreguidelines-pro-type-cstyle-cast,
+    cppcoreguidelines-virtual-class-destructor,
+    google-explicit-constructor,
+    llvm-include-order,
+    llvm-namespace-comment,
+    misc-const-correctness,
+    misc-redundant-expression,
+    misc-static-assert,
+    misc-uniqueptr-reset-release,
+    misc-unused-using-decls,
+    modernize-deprecated-headers,
+    modernize-make-shared,
+    modernize-make-unique,
+    modernize-pass-by-value,
+    modernize-redundant-void-arg,
+    modernize-return-braced-init-list,
+    modernize-type-traits,
+    modernize-unary-static-assert,
+    modernize-use-constraints,
+    modernize-use-emplace,
+    modernize-use-equals-default,
+    modernize-use-equals-delete,
+    modernize-use-nullptr,
+    modernize-use-override,
+    modernize-use-using,
+    performance-enum-size,
+    performance-faster-string-find,
+    performance-inefficient-algorithm,
+    performance-inefficient-string-concatenation,
+    performance-move-const-arg,
+    performance-move-constructor-init,
+    performance-no-automatic-move,
+    performance-noexcept-destructor,
+    performance-noexcept-swap,
+    performance-trivially-destructible,
+    performance-unnecessary-copy-initialization,
+    performance-unnecessary-value-param,
+    readability-const-return-type,
+    readability-container-contains,
+    readability-container-data-pointer,
+    readability-container-size-empty,
+    readability-duplicate-include,
+    readability-identifier-length,
+    readability-non-const-parameter,
+    readability-qualified-auto,
+    readability-redundant-control-flow,
+    readability-redundant-inline-specifier,
+    readability-redundant-smartptr-get,
+    readability-redundant-string-cstr,
+    readability-redundant-string-init,
+    readability-string-compare,
+    readability-use-std-min-max,
+    readability-uniqueptr-delete-release
+    '
+
+# Any activated check is considered as generating errors.
+WarningsAsErrors: '*'
+
+FormatStyle:
+    none

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,9 @@ project(
 )
 
 #---- Options.
-option(KokkosUtils_ENABLE_TESTS "Enable testing" ON)
-option(KokkosUtils_ENABLE_DOC   "Enable documentation" ON)
+option(KokkosUtils_ENABLE_TESTS      "Enable testing" ON)
+option(KokkosUtils_ENABLE_DOC        "Enable documentation" ON)
+option(KokkosUtils_ENABLE_CLANG_TIDY "Enable clang-tidy" OFF)
 
 #---- Global property that helps us keep track of files that will automatically be added
 #     to our Doxygen documentation.
@@ -100,6 +101,12 @@ target_link_libraries(
     INTERFACE
         Kokkos::kokkoscore
 )
+
+#---- Setup clang-tidy if needed.
+if(KokkosUtils_ENABLE_CLANG_TIDY)
+    configure_file(${CMAKE_SOURCE_DIR}/.clang-tidy ${CMAKE_BINARY_DIR}/.clang-tidy @ONLY)
+    set(CMAKE_CXX_CLANG_TIDY "clang-tidy" "--config-file=${CMAKE_BINARY_DIR}/.clang-tidy")
+endif()
 
 #---- Testing.
 if(KokkosUtils_ENABLE_TESTS)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,6 +32,12 @@
             "cacheVariables" : {"CMAKE_CXX_COMPILER" : "$penv{Kokkos_ROOT}/bin/nvcc_wrapper"}
         },
         {
+            // Inherit from this preset to use clang-tidy.
+            "name"          : "clang-tidy",
+            "hidden"        : true,
+            "cacheVariables": {"KokkosUtils_ENABLE_CLANG_TIDY" : "ON"}
+        },
+        {
             "name"           : "gcc-OpenMP",
             "inherits"       : ["default", "gcc"],
             "cacheVariables" : {
@@ -40,7 +46,7 @@
         },
         {
             "name"           : "clang-OpenMP",
-            "inherits"       : ["default", "clang"],
+            "inherits"       : ["default", "clang", "clang-tidy"],
             "cacheVariables" : {
                 "EXPECTED_Kokkos_DEVICES" : "SERIAL;OPENMP"
             }

--- a/include/kokkos-utils/callbacks/EventInProfileSectionRegexMatcher.hpp
+++ b/include/kokkos-utils/callbacks/EventInProfileSectionRegexMatcher.hpp
@@ -51,7 +51,6 @@ struct EventInProfileSectionRegexMatcher
     bool recording = false;
 };
 
-} // Kokkos::utils::callbacks
+} // namespace Kokkos::utils::callbacks
 
 #endif // KOKKOS_UTILS_CALLBACKS_EVENTINPROFILESECTIONREGEXMATCHER_HPP
-

--- a/tests/atomics/test_InsertOp.cpp
+++ b/tests/atomics/test_InsertOp.cpp
@@ -25,7 +25,7 @@ template <concepts::View view_t>
 struct InsertMinTest
 {
     view_t data;
-    int trials;
+    int trials = 0;
     utils::atomics::InsertMin inserter {};
 
     template <typename Exec>

--- a/tests/callbacks/TestWorkload.hpp
+++ b/tests/callbacks/TestWorkload.hpp
@@ -27,7 +27,7 @@ struct MyWorkload
         profile_section.start();
 
         {
-            Kokkos::Profiling::ScopedRegion guard_level_0("computation - level 0");
+            const Kokkos::Profiling::ScopedRegion guard_level_0("computation - level 0");
 
             Kokkos::parallel_for(
                 "computation - level 0 - pfor",
@@ -37,7 +37,7 @@ struct MyWorkload
             exec.fence("computation - level 0 - fence after pfor");
 
             {
-                Kokkos::Profiling::ScopedRegion guard_level_1("computation - level 1");
+                const Kokkos::Profiling::ScopedRegion guard_level_1("computation - level 1");
 
                 // Another kernel, a parallel reduce on the default execution space instance.
                 double my_result;
@@ -56,6 +56,6 @@ struct MyWorkload
     }
 };
 
-} // Kokkos::utils::tests::callbacks
+} // namespace Kokkos::utils::tests::callbacks
 
 #endif // KOKKOS_UTILS_TESTS_CALLBACKS_TESTWORKLOAD_HPP


### PR DESCRIPTION
## Summary

This PR enables `clang-tidy`.
