### PR TITLE
install: move callback helpers header from tests to include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ target_sources(
         include/kokkos-utils/callbacks/EventInProfileSectionRegexMatcher.hpp
         include/kokkos-utils/callbacks/EventRegexMatcher.hpp
         include/kokkos-utils/callbacks/Events.hpp
+        include/kokkos-utils/callbacks/Helpers.hpp
         include/kokkos-utils/callbacks/Listener.hpp
         include/kokkos-utils/callbacks/Manager.hpp
         include/kokkos-utils/callbacks/Matcher.hpp

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -37,8 +37,8 @@ get_target_property(KokkosUtils_TARGET_FILES_FOR_DOC KokkosUtils INTERFACE_SOURC
 get_property(KokkosUtils_FILES_FOR_DOC GLOBAL PROPERTY KokkosUtils_FILES_FOR_DOC)
 
 include(${CMAKE_SOURCE_DIR}/cmake/functions/list.cmake)
-check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 17)
-check_list_length(KokkosUtils_FILES_FOR_DOC        17)
+check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 18)
+check_list_length(KokkosUtils_FILES_FOR_DOC        16)
 
 #---- Add Doxygen as a target.
 #     See also https://cmake.org/cmake/help/latest/module/FindDoxygen.html.

--- a/include/kokkos-utils/callbacks/Helpers.hpp
+++ b/include/kokkos-utils/callbacks/Helpers.hpp
@@ -1,11 +1,11 @@
-#ifndef KOKKOS_UTILS_TESTS_HELPERS_HPP
-#define KOKKOS_UTILS_TESTS_HELPERS_HPP
+#ifndef KOKKOS_UTILS_CALLBACKS_HELPERS_HPP
+#define KOKKOS_UTILS_CALLBACKS_HELPERS_HPP
 
 #include "gmock/gmock.h"
 
 #include "kokkos-utils/callbacks/Manager.hpp"
 
-namespace Kokkos::utils::tests::callbacks
+namespace Kokkos::utils::callbacks
 {
 
 class ManagerTestFixture : public ::testing::Test
@@ -143,6 +143,6 @@ auto ContainsInOrder(Matchers&&... matchers) {
     return ::testing::MakePolymorphicMatcher(impl::ContainsInOrderMatcher<T, std::remove_cvref_t<Matchers>...>(std::forward<Matchers>(matchers)...));
 }
 
-} // namespace Kokkos::utils::tests::callbacks
+} // namespace Kokkos::utils::callbacks
 
-#endif // KOKKOS_UTILS_TESTS_HELPERS_HPP
+#endif // KOKKOS_UTILS_CALLBACKS_HELPERS_HPP

--- a/tests/callbacks/CMakeLists.txt
+++ b/tests/callbacks/CMakeLists.txt
@@ -1,4 +1,3 @@
-set_property(GLOBAL APPEND PROPERTY KokkosUtils_FILES_FOR_DOC ${CMAKE_CURRENT_SOURCE_DIR}/Helpers.hpp)
 set_property(GLOBAL APPEND PROPERTY KokkosUtils_FILES_FOR_DOC ${CMAKE_CURRENT_SOURCE_DIR}/TestWorkload.hpp)
 
 add_one_test(NAME Events)

--- a/tests/callbacks/test_Helpers.cpp
+++ b/tests/callbacks/test_Helpers.cpp
@@ -1,7 +1,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "tests/callbacks/Helpers.hpp"
+#include "kokkos-utils/callbacks/Helpers.hpp"
 
 /**
  * @file
@@ -11,7 +11,7 @@
  * @c Kokkos callback tests helpers
  * --------------------------------
  *
- * This group of tests check the behavior of the tests helpers implemented in @ref tests/callbacks/Helpers.hpp.
+ * This group of tests check the behavior of the tests helpers implemented in @ref kokkos-utils/callbacks/Helpers.hpp.
  */
 
 using execution_space = Kokkos::DefaultExecutionSpace;

--- a/tests/callbacks/test_Manager.cpp
+++ b/tests/callbacks/test_Manager.cpp
@@ -3,9 +3,9 @@
 
 #include "Kokkos_Core.hpp"
 
+#include "kokkos-utils/callbacks/Helpers.hpp"
 #include "kokkos-utils/impl/type_traits.hpp"
 
-#include "tests/callbacks/Helpers.hpp"
 #include "tests/callbacks/TestWorkload.hpp"
 
 /**

--- a/tests/callbacks/test_RecorderListener.cpp
+++ b/tests/callbacks/test_RecorderListener.cpp
@@ -7,9 +7,9 @@
 
 #include "kokkos-utils/callbacks/EventInProfileSectionRegexMatcher.hpp"
 #include "kokkos-utils/callbacks/EventRegexMatcher.hpp"
+#include "kokkos-utils/callbacks/Helpers.hpp"
 #include "kokkos-utils/callbacks/RecorderListener.hpp"
 
-#include "tests/callbacks/Helpers.hpp"
 #include "tests/callbacks/TestWorkload.hpp"
 
 /**


### PR DESCRIPTION
## Summary

This PR moves the callback helpers header from tests to include dir.
