### PR TITLE
callbacks: enable recorder with a single event type

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -38,7 +38,7 @@ get_property(KokkosUtils_FILES_FOR_DOC GLOBAL PROPERTY KokkosUtils_FILES_FOR_DOC
 
 include(${CMAKE_SOURCE_DIR}/cmake/functions/list.cmake)
 check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 18)
-check_list_length(KokkosUtils_FILES_FOR_DOC        16)
+check_list_length(KokkosUtils_FILES_FOR_DOC        17)
 
 #---- Add Doxygen as a target.
 #     See also https://cmake.org/cmake/help/latest/module/FindDoxygen.html.

--- a/include/kokkos-utils/callbacks/Matcher.hpp
+++ b/include/kokkos-utils/callbacks/Matcher.hpp
@@ -13,7 +13,7 @@ namespace impl
 template <typename, typename>
 struct IsMatcherFor;
 
-template <typename Callable, typename... Events>
+template <typename Callable, typename... Events> requires (sizeof...(Events) > 0)
 struct IsMatcherFor<Callable, Kokkos::Impl::type_list<Events...>>
 {
     static constexpr bool value = std::conjunction_v<std::is_invocable_r<bool, Callable, const Events&>...>;
@@ -23,7 +23,7 @@ struct IsMatcherFor<Callable, Kokkos::Impl::type_list<Events...>>
 
 /**
  * @brief Concept that models that a callable object is a matcher for the event types in @p EventTypeSubList
- *        if it is invocable with each event type passed by const ref and returns a boolean.
+ *        if it is invocable with each event type passed by @c const reference and returns a @c bool.
  */
 template <typename Callable, typename EventTypeSubList>
 concept Matcher = impl::IsMatcherFor<Callable, EventTypeSubList>::value;

--- a/include/kokkos-utils/callbacks/RecorderListener.hpp
+++ b/include/kokkos-utils/callbacks/RecorderListener.hpp
@@ -26,6 +26,7 @@ requires Matcher<MatcherType, Kokkos::Impl::type_list<EventTypes...>>
 class RecorderListener<MatcherType, EventTypes...>
 {
 public:
+    using matcher_t         = MatcherType;
     using event_type_list_t = Kokkos::Impl::type_list<EventTypes...>;
 
 public:

--- a/tests/callbacks/CMakeLists.txt
+++ b/tests/callbacks/CMakeLists.txt
@@ -1,3 +1,4 @@
+set_property(GLOBAL APPEND PROPERTY KokkosUtils_FILES_FOR_DOC ${CMAKE_CURRENT_SOURCE_DIR}/Helpers.hpp)
 set_property(GLOBAL APPEND PROPERTY KokkosUtils_FILES_FOR_DOC ${CMAKE_CURRENT_SOURCE_DIR}/TestWorkload.hpp)
 
 add_one_test(NAME Events)

--- a/tests/callbacks/Helpers.hpp
+++ b/tests/callbacks/Helpers.hpp
@@ -1,0 +1,25 @@
+#ifndef KOKKOS_UTILS_TESTS_CALLBACKS_HELPERS_HPP
+#define KOKKOS_UTILS_TESTS_CALLBACKS_HELPERS_HPP
+
+#include "kokkos-utils/callbacks/Events.hpp"
+
+namespace Kokkos::utils::tests::callbacks
+{
+namespace impl
+{
+template <typename>
+struct EventTestTypes;
+
+template <typename... EventTypes>
+struct EventTestTypes<Kokkos::Impl::type_list<EventTypes...>>
+{
+    using type = ::testing::Types<EventTypes...>;
+};
+} // namespace impl
+
+//! Useful type for defining a typed test suite over all types in @ref Kokkos::utils::callbacks::EventTypeList.
+using EventTestTypes = typename impl::EventTestTypes<Kokkos::utils::callbacks::EventTypeList>::type;
+
+} // namespace Kokkos::utils::tests::callbacks
+
+#endif // KOKKOS_UTILS_TESTS_CALLBACKS_HELPERS_HPP

--- a/tests/callbacks/test_Events.cpp
+++ b/tests/callbacks/test_Events.cpp
@@ -3,7 +3,7 @@
 
 #include "kokkos-utils/callbacks/Events.hpp"
 
-using execution_space = Kokkos::DefaultExecutionSpace;
+#include "tests/callbacks/Helpers.hpp"
 
 /**
  * @file
@@ -16,6 +16,8 @@ using execution_space = Kokkos::DefaultExecutionSpace;
  * This group of tests check the behavior of the event types defined in @ref Events.hpp
  * associated with @ref Kokkos profiling callbacks.
  */
+
+using execution_space = Kokkos::DefaultExecutionSpace;
 
 namespace Kokkos::utils::tests::callbacks
 {
@@ -179,17 +181,6 @@ struct EventTest<ProfileEvent> : public ::testing::Test
     ProfileEvent event {.name = "my profile event"};
     std::string expt_descr {"{name = \"my profile event\"}"};
 };
-
-template <typename>
-struct ImplEventTestTypes;
-
-template <typename... EventTypes>
-struct ImplEventTestTypes<Kokkos::Impl::type_list<EventTypes...>>
-{
-    using type = ::testing::Types<EventTypes...>;
-};
-
-using EventTestTypes = typename ImplEventTestTypes<EventTypeList>::type;
 
 TYPED_TEST_SUITE(EventTest, EventTestTypes);
 

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -41,6 +41,8 @@ TEST(EventRegexMatcher, traits)
     static_assert(std::movable<EventRegexMatcher>);
 
     static_assert( ! Matcher<EventRegexMatcher, BeginDeepCopyEvent>);
+
+    static_assert( ! Matcher<EventRegexMatcher, Kokkos::Impl::type_list<>>);
 }
 
 //! @test Check that @ref Kokkos::utils::callbacks::EventRegexMatcher works as expected.

--- a/tests/callbacks/test_RecorderListener.cpp
+++ b/tests/callbacks/test_RecorderListener.cpp
@@ -10,6 +10,7 @@
 #include "kokkos-utils/callbacks/Helpers.hpp"
 #include "kokkos-utils/callbacks/RecorderListener.hpp"
 
+#include "tests/callbacks/Helpers.hpp"
 #include "tests/callbacks/TestWorkload.hpp"
 
 /**
@@ -52,6 +53,26 @@ TEST(RecorderListener, traits)
     >);
 
     static_assert(Listener<event_in_profile_section_recorder_t>);
+}
+
+template <Event EvenType>
+class RecorderListenerSingleEventTypeTest : public ManagerTestFixture {};
+
+TYPED_TEST_SUITE(RecorderListenerSingleEventTypeTest, EventTestTypes);
+
+//! @test Ensure that @ref Kokkos::utils::callbacks::RecorderListener can be used with any event type from @ref Kokkos::utils::callbacks::EventTypeList.
+TYPED_TEST(RecorderListenerSingleEventTypeTest, record)
+{
+    using recorder_listener_t = RecorderListener<TypeParam>;
+    static_assert(std::same_as<typename recorder_listener_t::event_type_list_t, Kokkos::Impl::type_list<TypeParam>>);
+    static_assert(std::same_as<typename recorder_listener_t::matcher_t, AnyEventMatcher>);
+
+    const auto recorder = std::make_shared<recorder_listener_t>();
+
+    Manager::  register_listener(recorder);
+    Manager::unregister_listener(recorder.get());
+
+    ASSERT_EQ(recorder->recorded_events.size(), 0);
 }
 
 //! @test Check the behavior of @ref Kokkos::utils::callbacks::RecorderListener.


### PR DESCRIPTION
## Summary

This PR fixes `RecorderListener` to make it work with a single event type.
