### PR TITLE
callbacks: fixture virtual inheritance

### DIFF
--- a/include/kokkos-utils/callbacks/Helpers.hpp
+++ b/include/kokkos-utils/callbacks/Helpers.hpp
@@ -8,7 +8,7 @@
 namespace Kokkos::utils::callbacks
 {
 
-class ManagerTestFixture : public ::testing::Test
+class ManagerTestFixture : public virtual ::testing::Test
 {
 public:
     ManagerTestFixture()  { Kokkos::utils::callbacks::Manager::initialize(); }


### PR DESCRIPTION
## Summary

This is needed when a test class derives from many fixtures.
