### PR TITLE
ci(cuda): enable testing on blackwell120 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
                       compiler_family: gcc
                       base_image     : nvidia/cuda:12.8.1-devel-ubuntu24.04
                       platforms      : linux/amd64
-                      kokkos_arch    : VOLTA70
+                      kokkos_arch    : BLACKWELL120
                     - backend        : HIP
                       compiler_family: rocm
                       base_image     : rocm/dev-ubuntu-24.04:6.4
@@ -108,14 +108,15 @@ jobs:
 
     build-library-and-test:
         needs: [set-vars, build-image]
-        runs-on: [ubuntu-latest]
+        runs-on: ${{ matrix.runs_on || 'ubuntu-latest' }}
         strategy:
             fail-fast: false
             matrix:
                 include:
                     - backend        : Cuda
                       compiler_family: gcc
-                      run_tests      : false
+                      run_tests      : true
+                      runs_on        : [self-hosted, linux, amd64, docker, cuda, blackwell120]
                     - backend        : HIP
                       compiler_family: rocm
                       run_tests      : false

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -120,6 +120,11 @@
             "name"            : "clang-OpenMP",
             "configurePreset" : "clang-OpenMP",
             "inherits"        : "default"
+        },
+        {
+            "name"            : "gcc-Cuda",
+            "configurePreset" : "gcc-Cuda",
+            "inherits"        : "default"
         }
     ]
 }


### PR DESCRIPTION
I need `Kokkos` *4.6.01* to use `BACKWELL120` (https://github.com/kokkos/kokkos/commit/51b7c713dd636bbd6bb31d624efec7c505f29a55).