### PR TITLE
callbacks: add "in region" matcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ target_sources(
             include/kokkos-utils/atomics/InsertOp.hpp
 
             include/kokkos-utils/callbacks/EventInProfileSectionRegexMatcher.hpp
+            include/kokkos-utils/callbacks/EventInRegionMatcher.hpp
             include/kokkos-utils/callbacks/EventRegexMatcher.hpp
             include/kokkos-utils/callbacks/Events.hpp
             include/kokkos-utils/callbacks/Helpers.hpp

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -39,7 +39,7 @@ get_target_property(KokkosUtils_TARGET_FILES_FOR_DOC kokkosutils HEADER_SET_${Ko
 get_property(KokkosUtils_FILES_FOR_DOC GLOBAL PROPERTY KokkosUtils_FILES_FOR_DOC)
 
 include(${CMAKE_SOURCE_DIR}/cmake/functions/list.cmake)
-check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 23)
+check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 24)
 check_list_length(KokkosUtils_FILES_FOR_DOC        19)
 
 #---- Add Doxygen as a target.

--- a/include/kokkos-utils/callbacks/EventInRegionMatcher.hpp
+++ b/include/kokkos-utils/callbacks/EventInRegionMatcher.hpp
@@ -1,0 +1,66 @@
+#ifndef KOKKOS_UTILS_CALLBACKS_EVENTINREGIONMATCHER_HPP
+#define KOKKOS_UTILS_CALLBACKS_EVENTINREGIONMATCHER_HPP
+
+#include "kokkos-utils/callbacks/Events.hpp"
+#include "kokkos-utils/callbacks/Matcher.hpp"
+
+namespace Kokkos::utils::callbacks
+{
+
+/**
+ * @brief Matcher to select events that occur within a region.
+ *
+ * The region is selected by @ref matcher.
+ *
+ * Any event occuring between the matching @ref PushRegionEvent and its
+ * corresponding @ref PopRegionEvent will match.
+ */
+template <typename MatcherType> requires Matcher<MatcherType, Kokkos::Impl::type_list<PushRegionEvent>>
+struct EventInRegionMatcher
+{
+    static constexpr uint32_t invalid_nested_level = Kokkos::Experimental::finite_max_v<uint32_t>;
+
+    //! If the @p event matches @ref matcher, @ref matching is set to @c true.
+    bool operator()(const PushRegionEvent& event)
+    {
+        if (this->matching)
+        {
+            ++this->nested_level;
+            return true;
+        }
+        else if (matcher(event))
+        {
+            this->nested_level = 1;
+            this->matching     = true;
+        }
+
+        return false;
+    }
+
+    //! Decrement @ref nested_level if we are still matching.
+    bool operator()(const PopRegionEvent&)
+    {
+        if (this->matching)
+        {
+            --this->nested_level;
+
+            if (this->nested_level == 0)
+                this->matching = false;
+        }
+
+        return this->matching;
+    }
+
+    template <Event EventType>
+    bool operator()(const EventType&) const {
+        return matching;
+    }
+
+    MatcherType matcher {};
+    bool matching = false;
+    uint32_t nested_level = invalid_nested_level;
+};
+
+} // namespace Kokkos::utils::callbacks
+
+#endif // KOKKOS_UTILS_CALLBACKS_EVENTINREGIONMATCHER_HPP

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -5,6 +5,7 @@
 #include "kokkos-utils/impl/type_traits.hpp"
 
 #include "kokkos-utils/callbacks/EventInProfileSectionRegexMatcher.hpp"
+#include "kokkos-utils/callbacks/EventInRegionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventRegexMatcher.hpp"
 #include "kokkos-utils/callbacks/Matcher.hpp"
 
@@ -73,17 +74,47 @@ TEST(EventInProfileSectionRegexMatcher, in_profile_section_matcher)
 
     ASSERT_FALSE(matcher(CreateProfileSectionEvent{.name = "buried-profile-section", .section_id = section_id}));
 
-    ASSERT_FALSE(matcher(AllocateDataEvent{})) << "Expecting not to record the event before starting the region.";
+    ASSERT_FALSE(matcher(AllocateDataEvent{})) << "Expecting not to record the event before starting the section.";
 
     ASSERT_FALSE(matcher(StartProfileSectionEvent{.section_id = section_id}));
 
-    ASSERT_TRUE(matcher(AllocateDataEvent{})) << "Expecting to record the event inside the region.";
+    ASSERT_TRUE(matcher(AllocateDataEvent{})) << "Expecting to record the event inside the section.";
 
     ASSERT_FALSE(matcher(StopProfileSectionEvent{.section_id = section_id}));
 
-    ASSERT_FALSE(matcher(AllocateDataEvent{})) << "Expecting to record the event after stopping the region.";
+    ASSERT_FALSE(matcher(AllocateDataEvent{})) << "Expecting to record the event after stopping the section.";
 
     ASSERT_FALSE(matcher(DestroyProfileSectionEvent{.section_id = section_id}));
+}
+//! @test Check traits of @ref Kokkos::utils::callbacks::EventInRegionMatcher.
+TEST(EventInRegionMatcher, traits)
+{
+    using matcher_t = EventInRegionMatcher<EventRegexMatcher>;
+
+    static_assert(Matcher<matcher_t, EventTypeList>);
+    static_assert(std::movable<matcher_t>);
+}
+
+//! @test Check the behavior of @ref Kokkos::utils::callbacks::EventInRegionMatcher.
+TEST(EventInRegionMatcher, in_region_matcher)
+{
+    EventInRegionMatcher matcher(EventRegexMatcher{.regex = std::regex("buried-profile-region")});
+
+    ASSERT_FALSE(matcher(PushRegionEvent{.name = "not-the-one-we-want"}));
+
+    ASSERT_FALSE(matcher(AllocateDataEvent{}));
+
+    ASSERT_FALSE(matcher(PushRegionEvent{.name = "buried-profile-region"}));
+
+    ASSERT_TRUE(matcher(AllocateDataEvent{}));
+
+    ASSERT_TRUE(matcher(PushRegionEvent{.name = "nested-profile-region"}));
+
+    ASSERT_TRUE(matcher(AllocateDataEvent{}));
+
+    ASSERT_TRUE(matcher(PopRegionEvent{}));
+
+    ASSERT_FALSE(matcher(PopRegionEvent{}));
 }
 
 //! @test Check traits of @ref Kokkos::utils::callbacks::AnyEventMatcher.


### PR DESCRIPTION
## Summary

This is somewhat based on the `EventInProfileSectionRegexMatcher`, but in this case I've templated my matcher to make it more "composable".

## Related

- can probably be reused in #43 
