### PR TITLE
callbacks(profile section): make matcher more flexible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ target_sources(
         FILES
             include/kokkos-utils/atomics/InsertOp.hpp
 
-            include/kokkos-utils/callbacks/EventInProfileSectionRegexMatcher.hpp
+            include/kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp
             include/kokkos-utils/callbacks/EventInRegionMatcher.hpp
             include/kokkos-utils/callbacks/EventRegexMatcher.hpp
             include/kokkos-utils/callbacks/Events.hpp

--- a/include/kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp
+++ b/include/kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp
@@ -1,11 +1,10 @@
-#ifndef KOKKOS_UTILS_CALLBACKS_EVENTINPROFILESECTIONREGEXMATCHER_HPP
-#define KOKKOS_UTILS_CALLBACKS_EVENTINPROFILESECTIONREGEXMATCHER_HPP
-
-#include <regex>
+#ifndef KOKKOS_UTILS_CALLBACKS_EVENTINPROFILESECTIONMATCHER_HPP
+#define KOKKOS_UTILS_CALLBACKS_EVENTINPROFILESECTIONMATCHER_HPP
 
 #include "Kokkos_NumericTraits.hpp"
 
 #include "kokkos-utils/callbacks/Events.hpp"
+#include "kokkos-utils/callbacks/Matcher.hpp"
 
 namespace Kokkos::utils::callbacks
 {
@@ -13,17 +12,18 @@ namespace Kokkos::utils::callbacks
 /**
  * @brief Matcher to select events that occur within a profile section.
  *
- * The profile section is selected by matching its name to a regular expression.
+ * The profile section is selected by @ref matcher.
  */
-struct EventInProfileSectionRegexMatcher
+template <typename MatcherType> requires Matcher<MatcherType, Kokkos::Impl::type_list<CreateProfileSectionEvent>>
+struct EventInProfileSectionMatcher
 {
     static constexpr uint32_t invalid_section_id = Kokkos::Experimental::finite_max_v<uint32_t>;
 
     bool operator()(const CreateProfileSectionEvent& event)
     {
-        if (std::regex_search(event.name, this->regex))
+        if (matcher(event))
         {
-            if (section_id != invalid_section_id) Kokkos::abort("EventInProfileSectionRegexMatcher cannot match a create event twice.");
+            if (section_id != invalid_section_id) Kokkos::abort("EventInProfileSectionMatcher cannot match a create event twice.");
             section_id = event.section_id;
         }
         return false;
@@ -46,11 +46,11 @@ struct EventInProfileSectionRegexMatcher
         return recording;
     }
 
-    std::regex regex;
+    MatcherType matcher {};
     uint32_t section_id = invalid_section_id;
     bool recording = false;
 };
 
 } // namespace Kokkos::utils::callbacks
 
-#endif // KOKKOS_UTILS_CALLBACKS_EVENTINPROFILESECTIONREGEXMATCHER_HPP
+#endif // KOKKOS_UTILS_CALLBACKS_EVENTINPROFILESECTIONMATCHER_HPP

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -4,7 +4,7 @@
 
 #include "kokkos-utils/impl/type_traits.hpp"
 
-#include "kokkos-utils/callbacks/EventInProfileSectionRegexMatcher.hpp"
+#include "kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventInRegionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventRegexMatcher.hpp"
 #include "kokkos-utils/callbacks/Matcher.hpp"
@@ -58,19 +58,21 @@ TEST(EventRegexMatcher, regex_matcher)
     ASSERT_FALSE(matcher(AllocateDataEvent{.alloc = {.name = "not-this-other-allocation"}}));
 }
 
-//! @test Check traits of @ref Kokkos::utils::callbacks::EventInProfileSectionRegexMatcher.
-TEST(EventInProfileSectionRegexMatcher, traits)
+//! @test Check traits of @ref Kokkos::utils::callbacks::EventInProfileSectionMatcher.
+TEST(EventInProfileSectionMatcher, traits)
 {
-    static_assert(Matcher<EventInProfileSectionRegexMatcher, EventTypeList>);
-    static_assert(std::movable<EventInProfileSectionRegexMatcher>);
+    using matcher_t = EventInProfileSectionMatcher<EventRegexMatcher>;
+
+    static_assert(Matcher<matcher_t, EventTypeList>);
+    static_assert(std::movable<matcher_t>);
 }
 
-//! @test Check the behavior of @ref Kokkos::utils::callbacks::EventInProfileSectionRegexMatcher.
-TEST(EventInProfileSectionRegexMatcher, in_profile_section_matcher)
+//! @test Check the behavior of @ref Kokkos::utils::callbacks::EventInProfileSectionMatcher.
+TEST(EventInProfileSectionMatcher, in_profile_section_matcher)
 {
     constexpr uint32_t section_id = 2;
 
-    EventInProfileSectionRegexMatcher matcher(std::regex("buried-profile-section"));
+    EventInProfileSectionMatcher matcher{.matcher = EventRegexMatcher{.regex = std::regex("buried-profile-section")}};
 
     ASSERT_FALSE(matcher(CreateProfileSectionEvent{.name = "buried-profile-section", .section_id = section_id}));
 

--- a/tests/callbacks/test_RecorderListener.cpp
+++ b/tests/callbacks/test_RecorderListener.cpp
@@ -5,7 +5,7 @@
 
 #include "kokkos-utils/impl/type_traits.hpp"
 
-#include "kokkos-utils/callbacks/EventInProfileSectionRegexMatcher.hpp"
+#include "kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventRegexMatcher.hpp"
 #include "kokkos-utils/callbacks/Helpers.hpp"
 #include "kokkos-utils/callbacks/RecorderListener.hpp"
@@ -30,7 +30,7 @@ namespace Kokkos::utils::tests::callbacks
 using namespace Kokkos::utils::callbacks;
 
 //! Listener to record events that occur in a profile section.
-using event_in_profile_section_recorder_t = RecorderListener<EventInProfileSectionRegexMatcher, EventTypeList>;
+using event_in_profile_section_recorder_t = RecorderListener<EventInProfileSectionMatcher<EventRegexMatcher>, EventTypeList>;
 
 class RecorderListenerTest : public ManagerTestFixture
 {
@@ -78,7 +78,7 @@ TYPED_TEST(RecorderListenerSingleEventTypeTest, record)
 //! @test Check the behavior of @ref Kokkos::utils::callbacks::RecorderListener.
 TEST_F(RecorderListenerTest, recorded_events)
 {
-    EventInProfileSectionRegexMatcher matcher(std::regex("profile section"));
+    EventInProfileSectionMatcher matcher{.matcher = EventRegexMatcher{.regex = std::regex("profile section")}};
     const auto recorder = std::make_shared<event_in_profile_section_recorder_t>(std::move(matcher));
 
     const auto any_event_recorder = std::make_shared<RecorderListener<EventTypeList>>();


### PR DESCRIPTION
## Summary

Adds more flexibility to `EventInProfileSection[~~Regex~~]Matcher` :arrow_right: `EventInProfileSectionMatcher`.

This would *e.g.* enable someone to compose several matchers to tell if the profile section matches.