### PR TITLE
callbacks(listener): refactor concept to make it faster

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ option(KokkosUtils_ENABLE_TESTS      "Enable testing" ON)
 option(KokkosUtils_ENABLE_DOC        "Enable documentation" ON)
 option(KokkosUtils_ENABLE_CLANG_TIDY "Enable clang-tidy" OFF)
 
+#---- Enable further debugging by exporting compile commands.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 #---- Global property that helps us keep track of files that will automatically be added
 #     to our Doxygen documentation.
 define_property(GLOBAL PROPERTY KokkosUtils_FILES_FOR_DOC

--- a/include/kokkos-utils/callbacks/Listener.hpp
+++ b/include/kokkos-utils/callbacks/Listener.hpp
@@ -9,7 +9,11 @@ namespace Kokkos::utils::callbacks
 namespace impl
 {
 
-//! Helper struct needed for the implementation of @ref Kokkos::utils::callbacks::listener_event_type_list_t.
+/**
+ * Helper struct needed for the implementation of concepts and type traits such as:
+ *  - @ref Kokkos::utils::callbacks::listener_event_type_list_t
+ *  - @ref Kokkos::utils::callbacks::ListenerFor
+ */
 template <typename Callable>
 struct IsListenerFor
 {
@@ -19,16 +23,20 @@ struct IsListenerFor
 
 } // namespace impl
 
-//! Type list holding the event types that a callable object can be a listener for.
-template <typename Callable>
-using listener_event_type_list_t = Kokkos::Impl::filter_type_list_t<impl::IsListenerFor<Callable>::template type, EventTypeList>;
-
 /**
- * @brief Concept that models that a callable object to be registered as a listener by @ref Kokkos::utils::callbacks::Manager must
- *        have a non-empty list of event types that it can be a listener for.
+ * @brief @p Callable is a listener if it is invocable with at least one event type
+ *        from @ref Kokkos::utils::callbacks::EventTypeList passed by @c const reference and returns @c void.
  */
 template <typename Callable>
-concept Listener = ( ! std::same_as<listener_event_type_list_t<Callable>, Kokkos::Impl::type_list<>>);
+concept Listener = Kokkos::utils::impl::type_list_any_v<impl::IsListenerFor<Callable>::template type, EventTypeList>;
+
+//! Check that @p Callable is a listener for each event in @p EventTypes.
+template <typename Callable, typename... EventTypes>
+concept ListenerFor = Kokkos::utils::impl::type_list_all_v<impl::IsListenerFor<Callable>::template type, Kokkos::utils::impl::make_type_list_t<EventTypes...>>;
+
+//! Type list holding the event types that @p Callable can be a listener for.
+template <typename Callable>
+using listener_event_type_list_t = Kokkos::Impl::filter_type_list_t<impl::IsListenerFor<Callable>::template type, EventTypeList>;
 
 } // namespace Kokkos::utils::callbacks
 

--- a/include/kokkos-utils/impl/type_list.hpp
+++ b/include/kokkos-utils/impl/type_list.hpp
@@ -141,7 +141,7 @@ struct type_list_all;
 
 template <template <typename> class UnaryPred, class... Ts>
 struct type_list_all<UnaryPred, Kokkos::Impl::type_list<Ts...>>
-  : std::conjunction<UnaryPred<Ts>...> {};
+  : public std::conjunction<UnaryPred<Ts>...> {};
 
 template <template <typename> class UnaryPred, typename TypeList>
 inline constexpr bool type_list_all_v = type_list_all<UnaryPred, TypeList>::value;
@@ -157,9 +157,20 @@ inline constexpr bool type_list_all_v = type_list_all<UnaryPred, TypeList>::valu
 template <template <typename> class UnaryPred, class List>
 struct type_list_any;
 
+/// As of @c Cuda 12.8, using @c std::disjunction sometimes ends up erroring out with
+/// @code
+/// 'Kokkos::utils::impl::type_list_any<...>' has a base 'std::disjunction<...>' which has internal linkage [-Werror=subobject-linkage]
+/// @endcode
+/// It is the case if evaluating @ref Kokkos::utils::callbacks::Listener for a lambda.
+#if defined(__NVCC__)
 template <template <typename> class UnaryPred, class... Ts>
 struct type_list_any<UnaryPred, Kokkos::Impl::type_list<Ts...>>
-  : std::disjunction<UnaryPred<Ts>...> {};
+  : public std::bool_constant<(UnaryPred<Ts>::value || ...)> {};
+#else
+template <template <typename> class UnaryPred, class... Ts>
+struct type_list_any<UnaryPred, Kokkos::Impl::type_list<Ts...>>
+  : public std::disjunction<UnaryPred<Ts>...> {};
+#endif
 
 template <template <typename> class UnaryPred, typename TypeList>
 inline constexpr bool type_list_any_v = type_list_any<UnaryPred, TypeList>::value;

--- a/tests/callbacks/test_RecorderListener.cpp
+++ b/tests/callbacks/test_RecorderListener.cpp
@@ -52,7 +52,9 @@ TEST(RecorderListener, traits)
         EventTypeList
     >);
 
-    static_assert(Listener<event_in_profile_section_recorder_t>);
+    static_assert(Listener   <event_in_profile_section_recorder_t>);
+    static_assert(ListenerFor<event_in_profile_section_recorder_t, EventTypeList>);
+    static_assert(ListenerFor<event_in_profile_section_recorder_t, PushRegionEvent, PopRegionEvent>);
 }
 
 template <Event EvenType>


### PR DESCRIPTION
## Summary

This PR refactors the `Listener` concept to make it (much) faster.

## Description

Before this PR, the `Listener` concept would first collect all the event types that a callable can be a listener for and then check that the number of collected events is larger than 0.

Now, it uses `std::disjunction` which is short-circuiting.

IMO it is also more readable now.

To be noted that I hit a *internal linkage* issue with `std::disjunction` with **nvcc**. I sidestepped the issue with a preporcessing *if/else*.

## Related

- needs #53 
