### PR TITLE
callbacks(matcher): refactor to make more efficient / readable / consistent

### DIFF
--- a/include/kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp
+++ b/include/kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp
@@ -14,7 +14,7 @@ namespace Kokkos::utils::callbacks
  *
  * The profile section is selected by @ref matcher.
  */
-template <typename MatcherType> requires Matcher<MatcherType, Kokkos::Impl::type_list<CreateProfileSectionEvent>>
+template <typename MatcherType> requires MatcherFor<MatcherType, CreateProfileSectionEvent>
 struct EventInProfileSectionMatcher
 {
     static constexpr uint32_t invalid_section_id = Kokkos::Experimental::finite_max_v<uint32_t>;

--- a/include/kokkos-utils/callbacks/EventInRegionMatcher.hpp
+++ b/include/kokkos-utils/callbacks/EventInRegionMatcher.hpp
@@ -15,7 +15,7 @@ namespace Kokkos::utils::callbacks
  * Any event occuring between the matching @ref PushRegionEvent and its
  * corresponding @ref PopRegionEvent will match.
  */
-template <typename MatcherType> requires Matcher<MatcherType, Kokkos::Impl::type_list<PushRegionEvent>>
+template <typename MatcherType> requires MatcherFor<MatcherType, PushRegionEvent>
 struct EventInRegionMatcher
 {
     static constexpr uint32_t invalid_nested_level = Kokkos::Experimental::finite_max_v<uint32_t>;

--- a/include/kokkos-utils/callbacks/Matcher.hpp
+++ b/include/kokkos-utils/callbacks/Matcher.hpp
@@ -9,24 +9,34 @@ namespace Kokkos::utils::callbacks
 namespace impl
 {
 
-//! Helper struct needed for the implementation of the @ref Matcher concept.
-template <typename, typename>
-struct IsMatcherFor;
-
-template <typename Callable, typename... Events> requires (sizeof...(Events) > 0)
-struct IsMatcherFor<Callable, Kokkos::Impl::type_list<Events...>>
+/**
+ * Helper struct needed for the implementation of concepts and type traits such as:
+ *  - @ref Kokkos::utils::callbacks::matcher_event_type_list_t
+ *  - @ref ListenerFor
+ */
+template <typename Callable>
+struct IsMatcherFor
 {
-    static constexpr bool value = std::conjunction_v<std::is_invocable_r<bool, Callable, const Events&>...>;
+    template <Event EventType>
+    using type = std::is_invocable_r<bool, Callable, const EventType&>;
 };
 
 } // namespace impl
 
 /**
- * @brief Concept that models that a callable object is a matcher for the event types in @p EventTypeSubList
- *        if it is invocable with each event type passed by @c const reference and returns a @c bool.
+ * @brief @p Callable is a matcher if it is invocable with at least one event type
+ *        from @ref Kokkos::utils::callbacks::EventTypeList passed by @c const reference and returns @c bool.
  */
-template <typename Callable, typename EventTypeSubList>
-concept Matcher = impl::IsMatcherFor<Callable, EventTypeSubList>::value;
+template <typename Callable>
+concept Matcher = Kokkos::utils::impl::type_list_any_v<impl::IsMatcherFor<Callable>::template type, EventTypeList>;
+
+//! Check that @p Callable is a matcher for each event in @p EventTypes.
+template <typename Callable, typename... EventTypes>
+concept MatcherFor = Kokkos::utils::impl::type_list_all_v<impl::IsMatcherFor<Callable>::template type, Kokkos::utils::impl::make_type_list_t<EventTypes...>>;
+
+//! Type list holding the event types that @p Callable can be a matcher for.
+template <typename Callable>
+using matcher_event_type_list_t = Kokkos::Impl::filter_type_list_t<impl::IsMatcherFor<Callable>::template type, EventTypeList>;
 
 //! Matcher that returns @c true for any event.
 struct AnyEventMatcher

--- a/include/kokkos-utils/callbacks/RecorderListener.hpp
+++ b/include/kokkos-utils/callbacks/RecorderListener.hpp
@@ -22,8 +22,7 @@ class RecorderListener;
  * of the types @p EventTypes... and satisfy @p Matcher. The recorded events
  * are pushed back into a container in the order they are received.
  */
-template <typename MatcherType, Event... EventTypes>
-requires Matcher<MatcherType, Kokkos::Impl::type_list<EventTypes...>>
+template <typename MatcherType, Event... EventTypes> requires MatcherFor<MatcherType, EventTypes...>
 class RecorderListener<MatcherType, EventTypes...>
 {
 public:

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -28,7 +28,8 @@ using namespace Kokkos::utils::callbacks;
 //! @test Check traits of @ref Kokkos::utils::callbacks::EventRegexMatcher.
 TEST(EventRegexMatcher, traits)
 {
-    static_assert(Matcher<EventRegexMatcher, Kokkos::Impl::type_list<
+    static_assert(Matcher   <EventRegexMatcher>);
+    static_assert(MatcherFor<EventRegexMatcher,
         BeginParallelForEvent,
         BeginParallelReduceEvent,
         BeginParallelScanEvent,
@@ -38,12 +39,10 @@ TEST(EventRegexMatcher, traits)
         CreateProfileSectionEvent,
         PushRegionEvent,
         ProfileEvent
-    >>);
+    >);
     static_assert(std::movable<EventRegexMatcher>);
 
-    static_assert( ! Matcher<EventRegexMatcher, BeginDeepCopyEvent>);
-
-    static_assert( ! Matcher<EventRegexMatcher, Kokkos::Impl::type_list<>>);
+    static_assert( ! MatcherFor<EventRegexMatcher, BeginDeepCopyEvent>);
 }
 
 //! @test Check that @ref Kokkos::utils::callbacks::EventRegexMatcher works as expected.
@@ -63,7 +62,8 @@ TEST(EventInProfileSectionMatcher, traits)
 {
     using matcher_t = EventInProfileSectionMatcher<EventRegexMatcher>;
 
-    static_assert(Matcher<matcher_t, EventTypeList>);
+    static_assert(Matcher     <matcher_t>);
+    static_assert(MatcherFor  <matcher_t, EventTypeList>);
     static_assert(std::movable<matcher_t>);
 }
 
@@ -93,7 +93,8 @@ TEST(EventInRegionMatcher, traits)
 {
     using matcher_t = EventInRegionMatcher<EventRegexMatcher>;
 
-    static_assert(Matcher<matcher_t, EventTypeList>);
+    static_assert(Matcher     <matcher_t>);
+    static_assert(MatcherFor  <matcher_t, EventTypeList>);
     static_assert(std::movable<matcher_t>);
 }
 
@@ -122,7 +123,8 @@ TEST(EventInRegionMatcher, in_region_matcher)
 //! @test Check traits of @ref Kokkos::utils::callbacks::AnyEventMatcher.
 TEST(AnyEventMatcher, traits)
 {
-    static_assert(Matcher<AnyEventMatcher, EventTypeList>);
+    static_assert(Matcher     <AnyEventMatcher>);
+    static_assert(MatcherFor  <AnyEventMatcher, EventTypeList>);
     static_assert(std::movable<AnyEventMatcher>);
 }
 


### PR DESCRIPTION
## Summary

This PR aligns `Matcher` concepts with `Listener` concepts.

Specifically:
- `Matcher` takes only one template type parameter, as for `Listener`
- `MatcherFor` additionally takes one, many or a list of event types

## Related to

- similar to #51 
