### PR TITLE
impl(type list): more utilities for the type list

### DIFF
--- a/include/kokkos-utils/impl/type_list.hpp
+++ b/include/kokkos-utils/impl/type_list.hpp
@@ -11,6 +11,38 @@
 
 namespace Kokkos::utils::impl
 {
+//! @name Check if a type is a @c Kokkos::Impl::type_list.
+///@{
+template <typename T>
+struct is_type_list : public std::false_type {};
+
+template <typename... T>
+struct is_type_list<Kokkos::Impl::type_list<T...>> : public std::true_type {};
+
+template <typename T>
+inline constexpr bool is_type_list_v = is_type_list<T>::value;
+///@}
+
+//! @name Make a type list if it's not one already.
+///@{
+template <typename...>
+struct make_type_list;
+
+template <typename T> requires Kokkos::utils::impl::is_type_list_v<T>
+struct make_type_list<T>
+{
+    using type = T;
+};
+
+template <typename T, typename... Ts>
+struct make_type_list<T, Ts...>
+{
+    using type = Kokkos::Impl::type_list<T, Ts...>;
+};
+
+template <typename... Args>
+using make_type_list_t = typename make_type_list<Args...>::type;
+///@}
 
 //! @name Get the number of types in a @c Kokkos::Impl::type_list.
 ///@{
@@ -100,6 +132,37 @@ struct TypeListIndex<T, Kokkos::Impl::type_list<Head, Ts...>>
 
 template <typename T, typename S>
 inline constexpr size_t type_list_index_v = TypeListIndex<T, S>::value;
+///@}
+
+//! @name Check that a predicate is @c true for all types in a type list.
+///@{
+template <template <typename> class UnaryPred, class List>
+struct type_list_all;
+
+template <template <typename> class UnaryPred, class... Ts>
+struct type_list_all<UnaryPred, Kokkos::Impl::type_list<Ts...>>
+  : std::conjunction<UnaryPred<Ts>...> {};
+
+template <template <typename> class UnaryPred, typename TypeList>
+inline constexpr bool type_list_all_v = type_list_all<UnaryPred, TypeList>::value;
+///@}
+
+/**
+ * @name Check that a predicate is @c true for at least one of the types in a type list.
+ *
+ * @note Compared to @c Kokkos::Impl::type_list_any, this version is short-circuiting.
+ *       See also https://github.com/kokkos/kokkos/blob/db736f280b09ae5acaedab3b3ad6bc7d741e92bc/core/src/impl/Kokkos_Utilities.hpp#L171-L176.
+ */
+///@{
+template <template <typename> class UnaryPred, class List>
+struct type_list_any;
+
+template <template <typename> class UnaryPred, class... Ts>
+struct type_list_any<UnaryPred, Kokkos::Impl::type_list<Ts...>>
+  : std::disjunction<UnaryPred<Ts>...> {};
+
+template <template <typename> class UnaryPred, typename TypeList>
+inline constexpr bool type_list_any_v = type_list_any<UnaryPred, TypeList>::value;
 ///@}
 
 //! Calls the instantiation of the call operator of a callable object for each type in a @c Kokkos::Impl::type_list.

--- a/tests/impl/test_type_list.cpp
+++ b/tests/impl/test_type_list.cpp
@@ -17,6 +17,26 @@ namespace Kokkos::utils::tests::impl
 
 using type_list_t = Kokkos::Impl::type_list<char, short, int>;
 
+//! @test Check @ref Kokkos::utils::impl::is_type_list_v.
+TEST(impl, is_type_list_v)
+{
+    static_assert(! Kokkos::utils::impl::is_type_list_v<int>);
+    static_assert(! Kokkos::utils::impl::is_type_list_v<std::tuple<int, int>>);
+    static_assert(  Kokkos::utils::impl::is_type_list_v<type_list_t>);
+    static_assert(  Kokkos::utils::impl::is_type_list_v<Kokkos::Impl::type_list<>>);
+    static_assert(  Kokkos::utils::impl::is_type_list_v<Kokkos::Impl::type_list<int>>);
+    static_assert(  Kokkos::utils::impl::is_type_list_v<Kokkos::Impl::type_list<int, double>>);
+}
+
+//! @test Check @ref Kokkos::utils::impl::make_type_list_t.
+TEST(impl, make_type_list_t)
+{
+    static_assert(std::same_as<Kokkos::utils::impl::make_type_list_t<int        >, Kokkos::Impl::type_list<int        >>);
+    static_assert(std::same_as<Kokkos::utils::impl::make_type_list_t<int, double>, Kokkos::Impl::type_list<int, double>>);
+
+    static_assert(std::same_as<Kokkos::utils::impl::make_type_list_t<type_list_t>, type_list_t>);
+}
+
 //! @test Check @ref Kokkos::utils::impl::type_list_size_v.
 TEST(impl, type_list_size_v)
 {
@@ -84,6 +104,21 @@ TEST(impl, type_list_index_v)
     static_assert(type_list_index_v<char,  type_list_t> == 0);
     static_assert(type_list_index_v<short, type_list_t> == 1);
     static_assert(type_list_index_v<int,   type_list_t> == 2);
+}
+
+//! @test Check @ref Kokkos::utils::impl::type_list_all_v.
+TEST(impl, type_list_all_v)
+{
+    static_assert(  Kokkos::utils::impl::type_list_all_v<std::is_floating_point, Kokkos::Impl::type_list<float, double>>);
+    static_assert(! Kokkos::utils::impl::type_list_all_v<std::is_floating_point, Kokkos::Impl::type_list<float, double, int>>);
+}
+
+//! @test Check @ref Kokkos::utils::impl::type_list_any_v.
+TEST(impl, type_list_any_v)
+{
+    static_assert(  Kokkos::utils::impl::type_list_any_v<std::is_floating_point, Kokkos::Impl::type_list<float, std::string, int>>);
+    static_assert(  Kokkos::utils::impl::type_list_any_v<std::is_integral,       Kokkos::Impl::type_list<float, std::string, int>>);
+    static_assert(! Kokkos::utils::impl::type_list_any_v<std::is_enum,           Kokkos::Impl::type_list<float, std::string, int>>);
 }
 
 //! @test Check @ref Kokkos::utils::impl::for_each.


### PR DESCRIPTION
## Summary

This PR introduces (many) more nice utilities for `Kokkos::Impl::type_list` that are needed by:
- #52 
- #51
