### PR TITLE
ci: fix for files-changed when running on the develop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,10 @@ jobs:
                       platforms      : linux/amd64
         steps:
             - uses: actions/checkout@v4
+              with:
+                  set-safe-directory: true
+
+            - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
             - id: changed-files
               uses: tj-actions/changed-files@v46.0.5


### PR DESCRIPTION
## Summary

I'm not sure why I need this fix, but it appears that `files-changed` has troubles with the dubious ownership `Git` repository when the CI is running on the `develop`.

## Related to

- #55 
