### PR TITLE
callbacks: make traits even faster

### DIFF
--- a/include/kokkos-utils/callbacks/Listener.hpp
+++ b/include/kokkos-utils/callbacks/Listener.hpp
@@ -32,7 +32,7 @@ concept Listener = Kokkos::utils::impl::type_list_any_v<impl::IsListenerFor<Call
 
 //! Check that @p Callable is a listener for each event in @p EventTypes.
 template <typename Callable, typename... EventTypes>
-concept ListenerFor = Kokkos::utils::impl::type_list_all_v<impl::IsListenerFor<Callable>::template type, Kokkos::utils::impl::make_type_list_t<EventTypes...>>;
+concept ListenerFor = Kokkos::utils::impl::type_list_all_v<impl::IsListenerFor<Callable>::template type, EventTypes...>;
 
 //! Type list holding the event types that @p Callable can be a listener for.
 template <typename Callable>

--- a/include/kokkos-utils/callbacks/Matcher.hpp
+++ b/include/kokkos-utils/callbacks/Matcher.hpp
@@ -12,7 +12,7 @@ namespace impl
 /**
  * Helper struct needed for the implementation of concepts and type traits such as:
  *  - @ref Kokkos::utils::callbacks::matcher_event_type_list_t
- *  - @ref ListenerFor
+ *  - @ref Kokkos::utils::callbacks::Matcher
  */
 template <typename Callable>
 struct IsMatcherFor
@@ -32,7 +32,7 @@ concept Matcher = Kokkos::utils::impl::type_list_any_v<impl::IsMatcherFor<Callab
 
 //! Check that @p Callable is a matcher for each event in @p EventTypes.
 template <typename Callable, typename... EventTypes>
-concept MatcherFor = Kokkos::utils::impl::type_list_all_v<impl::IsMatcherFor<Callable>::template type, Kokkos::utils::impl::make_type_list_t<EventTypes...>>;
+concept MatcherFor = Kokkos::utils::impl::type_list_all_v<impl::IsMatcherFor<Callable>::template type, EventTypes...>;
 
 //! Type list holding the event types that @p Callable can be a matcher for.
 template <typename Callable>

--- a/include/kokkos-utils/callbacks/RecorderListener.hpp
+++ b/include/kokkos-utils/callbacks/RecorderListener.hpp
@@ -22,7 +22,7 @@ class RecorderListener;
  * of the types @p EventTypes... and satisfy @p Matcher. The recorded events
  * are pushed back into a container in the order they are received.
  */
-template <typename MatcherType, Event... EventTypes> requires MatcherFor<MatcherType, EventTypes...>
+template <typename MatcherType, Event... EventTypes> requires (sizeof...(EventTypes) > 0 && MatcherFor<MatcherType, EventTypes...>)
 class RecorderListener<MatcherType, EventTypes...>
 {
 public:
@@ -92,7 +92,7 @@ template <Event... EventTypes>
 class RecorderListener<EventTypes...> : public RecorderListener<AnyEventMatcher, EventTypes...> {};
 
 template <Event... EventTypes>
-class RecorderListener<Kokkos::Impl::type_list<EventTypes...>> : public RecorderListener<EventTypes...> {};
+class RecorderListener<Kokkos::Impl::type_list<EventTypes...>> : public RecorderListener<AnyEventMatcher, EventTypes...> {};
 
 } // namespace Kokkos::utils::callbacks
 

--- a/include/kokkos-utils/impl/type_list.hpp
+++ b/include/kokkos-utils/impl/type_list.hpp
@@ -136,15 +136,21 @@ inline constexpr size_t type_list_index_v = TypeListIndex<T, S>::value;
 
 //! @name Check that a predicate is @c true for all types in a type list.
 ///@{
-template <template <typename> class UnaryPred, class List>
+template <template <typename> typename UnaryPred, typename...>
 struct type_list_all;
 
-template <template <typename> class UnaryPred, class... Ts>
+//! Specialization for a "direct" list of types.
+template <template <typename> typename UnaryPred, typename T, typename... Ts>
+struct type_list_all<UnaryPred, T, Ts...>
+  : public std::conjunction<UnaryPred<T>, UnaryPred<Ts>...> {};
+
+//! Specialization for a list of types given as @c Kokkos::Impl::type_list.
+template <template <typename> typename UnaryPred, typename... Ts>
 struct type_list_all<UnaryPred, Kokkos::Impl::type_list<Ts...>>
   : public std::conjunction<UnaryPred<Ts>...> {};
 
-template <template <typename> class UnaryPred, typename TypeList>
-inline constexpr bool type_list_all_v = type_list_all<UnaryPred, TypeList>::value;
+template <template <typename> typename UnaryPred, typename... TypeList>
+inline constexpr bool type_list_all_v = type_list_all<UnaryPred, TypeList...>::value;
 ///@}
 
 /**
@@ -154,26 +160,47 @@ inline constexpr bool type_list_all_v = type_list_all<UnaryPred, TypeList>::valu
  *       See also https://github.com/kokkos/kokkos/blob/db736f280b09ae5acaedab3b3ad6bc7d741e92bc/core/src/impl/Kokkos_Utilities.hpp#L171-L176.
  */
 ///@{
-template <template <typename> class UnaryPred, class List>
+template <template <typename> typename UnaryPred, typename...>
 struct type_list_any;
 
+/// @name Specialization for a "direct" list of types.
 /// As of @c Cuda 12.8, using @c std::disjunction sometimes ends up erroring out with
 /// @code
 /// 'Kokkos::utils::impl::type_list_any<...>' has a base 'std::disjunction<...>' which has internal linkage [-Werror=subobject-linkage]
 /// @endcode
 /// It is the case if evaluating @ref Kokkos::utils::callbacks::Listener for a lambda.
+///@{
 #if defined(__NVCC__)
-template <template <typename> class UnaryPred, class... Ts>
+template <template <typename> typename UnaryPred, typename T, typename... Ts>
+struct type_list_any<UnaryPred, T, Ts...>
+  : public std::bool_constant<UnaryPred<T>::value || (UnaryPred<Ts>::value || ...)> {};
+#else
+template <template <typename> typename UnaryPred, typename T, typename... Ts>
+struct type_list_any<UnaryPred, T, Ts...>
+  : public std::disjunction<UnaryPred<T>, UnaryPred<Ts>...> {};
+#endif
+///@}
+
+/// @name Specialization for a list of types given as @c Kokkos::Impl::type_list.
+/// As of @c Cuda 12.8, using @c std::disjunction sometimes ends up erroring out with
+/// @code
+/// 'Kokkos::utils::impl::type_list_any<...>' has a base 'std::disjunction<...>' which has internal linkage [-Werror=subobject-linkage]
+/// @endcode
+/// It is the case if evaluating @ref Kokkos::utils::callbacks::Listener for a lambda.
+///@{
+#if defined(__NVCC__)
+template <template <typename> typename UnaryPred, typename... Ts>
 struct type_list_any<UnaryPred, Kokkos::Impl::type_list<Ts...>>
   : public std::bool_constant<(UnaryPred<Ts>::value || ...)> {};
 #else
-template <template <typename> class UnaryPred, class... Ts>
+template <template <typename> typename UnaryPred, typename... Ts>
 struct type_list_any<UnaryPred, Kokkos::Impl::type_list<Ts...>>
   : public std::disjunction<UnaryPred<Ts>...> {};
 #endif
+///@}
 
-template <template <typename> class UnaryPred, typename TypeList>
-inline constexpr bool type_list_any_v = type_list_any<UnaryPred, TypeList>::value;
+template <template <typename> typename UnaryPred, typename... TypeList>
+inline constexpr bool type_list_any_v = type_list_any<UnaryPred, TypeList...>::value;
 ///@}
 
 //! Calls the instantiation of the call operator of a callable object for each type in a @c Kokkos::Impl::type_list.

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -101,17 +101,17 @@ TEST(EventInRegionMatcher, traits)
 //! @test Check the behavior of @ref Kokkos::utils::callbacks::EventInRegionMatcher.
 TEST(EventInRegionMatcher, in_region_matcher)
 {
-    EventInRegionMatcher matcher(EventRegexMatcher{.regex = std::regex("buried-profile-region")});
+    EventInRegionMatcher matcher(EventRegexMatcher{.regex = std::regex("buried-region")});
 
     ASSERT_FALSE(matcher(PushRegionEvent{.name = "not-the-one-we-want"}));
 
     ASSERT_FALSE(matcher(AllocateDataEvent{}));
 
-    ASSERT_FALSE(matcher(PushRegionEvent{.name = "buried-profile-region"}));
+    ASSERT_FALSE(matcher(PushRegionEvent{.name = "buried-region"}));
 
     ASSERT_TRUE(matcher(AllocateDataEvent{}));
 
-    ASSERT_TRUE(matcher(PushRegionEvent{.name = "nested-profile-region"}));
+    ASSERT_TRUE(matcher(PushRegionEvent{.name = "nested-region"}));
 
     ASSERT_TRUE(matcher(AllocateDataEvent{}));
 

--- a/tests/impl/test_type_list.cpp
+++ b/tests/impl/test_type_list.cpp
@@ -111,6 +111,9 @@ TEST(impl, type_list_all_v)
 {
     static_assert(  Kokkos::utils::impl::type_list_all_v<std::is_floating_point, Kokkos::Impl::type_list<float, double>>);
     static_assert(! Kokkos::utils::impl::type_list_all_v<std::is_floating_point, Kokkos::Impl::type_list<float, double, int>>);
+
+    static_assert(  Kokkos::utils::impl::type_list_all_v<std::is_floating_point, float, double>);
+    static_assert(! Kokkos::utils::impl::type_list_all_v<std::is_floating_point, float, double, int>);
 }
 
 //! @test Check @ref Kokkos::utils::impl::type_list_any_v.
@@ -119,6 +122,10 @@ TEST(impl, type_list_any_v)
     static_assert(  Kokkos::utils::impl::type_list_any_v<std::is_floating_point, Kokkos::Impl::type_list<float, std::string, int>>);
     static_assert(  Kokkos::utils::impl::type_list_any_v<std::is_integral,       Kokkos::Impl::type_list<float, std::string, int>>);
     static_assert(! Kokkos::utils::impl::type_list_any_v<std::is_enum,           Kokkos::Impl::type_list<float, std::string, int>>);
+
+    static_assert(  Kokkos::utils::impl::type_list_any_v<std::is_floating_point, float, std::string, int>);
+    static_assert(  Kokkos::utils::impl::type_list_any_v<std::is_integral,       float, std::string, int>);
+    static_assert(! Kokkos::utils::impl::type_list_any_v<std::is_enum,           float, std::string, int>);
 }
 
 //! @test Check @ref Kokkos::utils::impl::for_each.


### PR DESCRIPTION
## Summary

This PR tries to simplify further the matcher and listener traits.

This is done by loosening the requirement that `type_list_any` and `type_list_all` only work with `Kokkos::Impl::type_list`.

Now, they also work with types given without it.

## Description

~~I encountered issues with the many specializations of `RecorderListener`. To circumvent the issue, I've removed the specializations that only use events.~~ Just needed a few more constraints.

## Related to

- #52
- #53 
