### PR TITLE
callbacks(matcher): match by exact event name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ target_sources(
 
             include/kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp
             include/kokkos-utils/callbacks/EventInRegionMatcher.hpp
+            include/kokkos-utils/callbacks/EventNameMatcher.hpp
             include/kokkos-utils/callbacks/EventRegexMatcher.hpp
             include/kokkos-utils/callbacks/Events.hpp
             include/kokkos-utils/callbacks/Helpers.hpp

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -39,7 +39,7 @@ get_target_property(KokkosUtils_TARGET_FILES_FOR_DOC kokkosutils HEADER_SET_${Ko
 get_property(KokkosUtils_FILES_FOR_DOC GLOBAL PROPERTY KokkosUtils_FILES_FOR_DOC)
 
 include(${CMAKE_SOURCE_DIR}/cmake/functions/list.cmake)
-check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 24)
+check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 25)
 check_list_length(KokkosUtils_FILES_FOR_DOC        19)
 
 #---- Add Doxygen as a target.

--- a/include/kokkos-utils/callbacks/EventNameMatcher.hpp
+++ b/include/kokkos-utils/callbacks/EventNameMatcher.hpp
@@ -1,0 +1,27 @@
+#ifndef KOKKOS_UTILS_CALLBACKS_EVENTNAMEMATCHER_HPP
+#define KOKKOS_UTILS_CALLBACKS_EVENTNAMEMATCHER_HPP
+
+#include "kokkos-utils/callbacks/Events.hpp"
+
+namespace Kokkos::utils::callbacks
+{
+
+//! Matcher to select events whose name matches @ref name.
+struct EventNameMatcher
+{
+    template <NamedEvent EventType>
+    bool operator()(const EventType& event) const {
+        return event.name == this->name;
+    }
+
+    template <DataEvent EventType>
+    bool operator()(const EventType& event) const {
+        return event.alloc.name == this->name;
+    }
+
+    std::string name;
+};
+
+} // namespace Kokkos::utils::callbacks
+
+#endif // KOKKOS_UTILS_CALLBACKS_EVENTNAMEMATCHER_HPP

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -6,6 +6,7 @@
 
 #include "kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventInRegionMatcher.hpp"
+#include "kokkos-utils/callbacks/EventNameMatcher.hpp"
 #include "kokkos-utils/callbacks/EventRegexMatcher.hpp"
 #include "kokkos-utils/callbacks/Matcher.hpp"
 
@@ -23,23 +24,27 @@ using execution_space = Kokkos::DefaultExecutionSpace;
 
 namespace Kokkos::utils::tests::callbacks
 {
+
 using namespace Kokkos::utils::callbacks;
+
+//! List of event types that have a name.
+using named_event_type_list_t = Kokkos::Impl::type_list<
+    BeginParallelForEvent,
+    BeginParallelReduceEvent,
+    BeginParallelScanEvent,
+    BeginFenceEvent,
+    AllocateDataEvent,
+    DeallocateDataEvent,
+    CreateProfileSectionEvent,
+    PushRegionEvent,
+    ProfileEvent
+>;
 
 //! @test Check traits of @ref Kokkos::utils::callbacks::EventRegexMatcher.
 TEST(EventRegexMatcher, traits)
 {
     static_assert(Matcher   <EventRegexMatcher>);
-    static_assert(MatcherFor<EventRegexMatcher,
-        BeginParallelForEvent,
-        BeginParallelReduceEvent,
-        BeginParallelScanEvent,
-        BeginFenceEvent,
-        AllocateDataEvent,
-        DeallocateDataEvent,
-        CreateProfileSectionEvent,
-        PushRegionEvent,
-        ProfileEvent
-    >);
+    static_assert(MatcherFor<EventRegexMatcher, named_event_type_list_t>);
     static_assert(std::movable<EventRegexMatcher>);
 
     static_assert( ! MatcherFor<EventRegexMatcher, BeginDeepCopyEvent>);
@@ -55,6 +60,23 @@ TEST(EventRegexMatcher, regex_matcher)
 
     ASSERT_TRUE( matcher(AllocateDataEvent{.alloc = {.name = "buried-allocation-to-time"}}));
     ASSERT_FALSE(matcher(AllocateDataEvent{.alloc = {.name = "not-this-other-allocation"}}));
+}
+
+//! @test Check traits of @ref Kokkos::utils::callbacks::EventNameMatcher.
+TEST(EventNameMatcher, traits)
+{
+    static_assert(Matcher     <EventNameMatcher>);
+    static_assert(MatcherFor  <EventNameMatcher, named_event_type_list_t>);
+    static_assert(std::movable<EventNameMatcher>);
+}
+
+//! @test Check that @ref Kokkos::utils::callbacks::EventNameMatcher
+TEST(EventNameMatcher, by_name)
+{
+    const EventNameMatcher matcher{.name = "named-as-I-like-it"};
+
+    ASSERT_FALSE(matcher(AllocateDataEvent{.alloc = {.name = "named-deep-copy"}}));
+    ASSERT_TRUE (matcher(AllocateDataEvent{.alloc = {.name = "named-as-I-like-it"}}));
 }
 
 //! @test Check traits of @ref Kokkos::utils::callbacks::EventInProfileSectionMatcher.


### PR DESCRIPTION
## Summary

This is a cheaper alternative for `EventRegexMatcher` when the name strict equality is required.

