### PR TITLE
callbacks(events): allow restricting a matcher to a subset of types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ target_sources(
             include/kokkos-utils/callbacks/EventInRegionMatcher.hpp
             include/kokkos-utils/callbacks/EventNameMatcher.hpp
             include/kokkos-utils/callbacks/EventRegexMatcher.hpp
+            include/kokkos-utils/callbacks/EventTypeMatcher.hpp
             include/kokkos-utils/callbacks/Events.hpp
             include/kokkos-utils/callbacks/Helpers.hpp
             include/kokkos-utils/callbacks/Listener.hpp

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -39,7 +39,7 @@ get_target_property(KokkosUtils_TARGET_FILES_FOR_DOC kokkosutils HEADER_SET_${Ko
 get_property(KokkosUtils_FILES_FOR_DOC GLOBAL PROPERTY KokkosUtils_FILES_FOR_DOC)
 
 include(${CMAKE_SOURCE_DIR}/cmake/functions/list.cmake)
-check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 25)
+check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 26)
 check_list_length(KokkosUtils_FILES_FOR_DOC        19)
 
 #---- Add Doxygen as a target.

--- a/include/kokkos-utils/callbacks/EventTypeMatcher.hpp
+++ b/include/kokkos-utils/callbacks/EventTypeMatcher.hpp
@@ -1,0 +1,28 @@
+#ifndef KOKKOS_UTILS_CALLBACKS_EVENTTYPEMATCHER_HPP
+#define KOKKOS_UTILS_CALLBACKS_EVENTTYPEMATCHER_HPP
+
+#include "kokkos-utils/callbacks/Events.hpp"
+#include "kokkos-utils/callbacks/Matcher.hpp"
+
+namespace Kokkos::utils::callbacks
+{
+
+/**
+ * @brief Restrict the event types that can be matched by @ref matcher to the subset @p EventTypes.
+ *
+ * @note The @p EventTypes are expected to be valid event types for @p MatcherType.
+ */
+template <Matcher MatcherType, Event... EventTypes> requires MatcherFor<MatcherType, EventTypes...>
+struct EventTypeMatcher
+{
+    template <EventOneOf<EventTypes...> EventType> requires MatcherFor<MatcherType, EventType>
+    bool operator()(const EventType& event) {
+        return matcher(event);
+    }
+
+    MatcherType matcher;
+};
+
+} // namespace Kokkos::utils::callbacks
+
+#endif // KOKKOS_UTILS_CALLBACKS_EVENTTYPEMATCHER_HPP

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -8,6 +8,7 @@
 #include "kokkos-utils/callbacks/EventInRegionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventNameMatcher.hpp"
 #include "kokkos-utils/callbacks/EventRegexMatcher.hpp"
+#include "kokkos-utils/callbacks/EventTypeMatcher.hpp"
 #include "kokkos-utils/callbacks/Matcher.hpp"
 
 /**
@@ -158,6 +159,26 @@ TEST(AnyEventMatcher, operator_parentheses)
     Kokkos::utils::impl::for_each<EventTypeList>([&] <Event EventType>() {
         static_assert(matcher(EventType{}));
     });
+}
+
+//! @test Check traits of @ref Kokkos::utils::callbacks::EventTypeMatcher.
+TEST(EventTypeMatcher, traits)
+{
+    using matcher_t = EventTypeMatcher<AnyEventMatcher, BeginFenceEvent, PushRegionEvent>;
+
+    static_assert(Matcher     <matcher_t>);
+    static_assert(MatcherFor  <matcher_t, BeginFenceEvent, PushRegionEvent>);
+    static_assert(std::same_as<matcher_event_type_list_t<matcher_t>, Kokkos::Impl::type_list<BeginFenceEvent, PushRegionEvent>>);
+    static_assert(std::movable<matcher_t>);
+}
+
+//! @test Check the behavior of @ref Kokkos::utils::callbacks::EventTypeMatcher.
+TEST(EventTypeMatcher, operator_parentheses)
+{
+    EventTypeMatcher<AnyEventMatcher, BeginFenceEvent, PushRegionEvent> matcher {};
+
+    ASSERT_TRUE(matcher(PushRegionEvent{}));
+    ASSERT_TRUE(matcher(BeginFenceEvent{}));
 }
 
 } // namespace Kokkos::utils::tests::callbacks


### PR DESCRIPTION
## Summary

This matcher can be useful to restrict the amount of enabled callbacks to the bare minimum needed.

