### PR TITLE
callbacks(events): refactor `Event[In]RegionMatcher` to allow matching opening/closing events instead of "within" events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Ignore CMake build directory
 build*/*
+
+# Any log file.
+*.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,9 @@ target_sources(
 
             include/kokkos-utils/callbacks/EventBeginEndEventIdMatcher.hpp
             include/kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp
-            include/kokkos-utils/callbacks/EventInRegionMatcher.hpp
             include/kokkos-utils/callbacks/EventNameMatcher.hpp
             include/kokkos-utils/callbacks/EventRegexMatcher.hpp
+            include/kokkos-utils/callbacks/EventRegionMatcher.hpp
             include/kokkos-utils/callbacks/EventTypeMatcher.hpp
             include/kokkos-utils/callbacks/Events.hpp
             include/kokkos-utils/callbacks/Helpers.hpp

--- a/include/kokkos-utils/callbacks/EventRegionMatcher.hpp
+++ b/include/kokkos-utils/callbacks/EventRegionMatcher.hpp
@@ -1,5 +1,5 @@
-#ifndef KOKKOS_UTILS_CALLBACKS_EVENTINREGIONMATCHER_HPP
-#define KOKKOS_UTILS_CALLBACKS_EVENTINREGIONMATCHER_HPP
+#ifndef KOKKOS_UTILS_CALLBACKS_EVENTREGIONMATCHER_HPP
+#define KOKKOS_UTILS_CALLBACKS_EVENTREGIONMATCHER_HPP
 
 #include "kokkos-utils/callbacks/Events.hpp"
 #include "kokkos-utils/callbacks/Matcher.hpp"
@@ -14,9 +14,12 @@ namespace Kokkos::utils::callbacks
  *
  * Any event occuring between the matching @ref PushRegionEvent and its
  * corresponding @ref PopRegionEvent will match.
+ *
+ * Set @p TrueOnBoundary to @c true if it must return @c true for the opening @ref PushRegionEvent and
+ * closing @ref PopRegionEvent and @c false otherwise.
  */
-template <typename MatcherType> requires MatcherFor<MatcherType, PushRegionEvent>
-struct EventInRegionMatcher
+template <typename MatcherType, bool TrueOnBoundary = false> requires MatcherFor<MatcherType, PushRegionEvent>
+struct EventRegionMatcher
 {
     static constexpr uint32_t invalid_nested_level = Kokkos::Experimental::finite_max_v<uint32_t>;
 
@@ -26,15 +29,16 @@ struct EventInRegionMatcher
         if (this->matching)
         {
             ++this->nested_level;
-            return true;
+            return ! TrueOnBoundary;
         }
         else if (matcher(event))
         {
             this->nested_level = 1;
             this->matching     = true;
+            return TrueOnBoundary;
         }
 
-        return false;
+        return TrueOnBoundary ? false : this->matching;
     }
 
     //! Decrement @ref nested_level if we are still matching.
@@ -45,15 +49,18 @@ struct EventInRegionMatcher
             --this->nested_level;
 
             if (this->nested_level == 0)
+            {
                 this->matching = false;
+                return TrueOnBoundary;
+            }
         }
 
-        return this->matching;
+        return TrueOnBoundary ? false : this->matching;
     }
 
     template <Event EventType>
     bool operator()(const EventType&) const {
-        return matching;
+        return TrueOnBoundary ? false : this->matching;
     }
 
     MatcherType matcher {};
@@ -63,4 +70,4 @@ struct EventInRegionMatcher
 
 } // namespace Kokkos::utils::callbacks
 
-#endif // KOKKOS_UTILS_CALLBACKS_EVENTINREGIONMATCHER_HPP
+#endif // KOKKOS_UTILS_CALLBACKS_EVENTREGIONMATCHER_HPP

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -6,9 +6,9 @@
 
 #include "kokkos-utils/callbacks/EventBeginEndEventIdMatcher.hpp"
 #include "kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp"
-#include "kokkos-utils/callbacks/EventInRegionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventNameMatcher.hpp"
 #include "kokkos-utils/callbacks/EventRegexMatcher.hpp"
+#include "kokkos-utils/callbacks/EventRegionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventTypeMatcher.hpp"
 #include "kokkos-utils/callbacks/Matcher.hpp"
 
@@ -112,20 +112,20 @@ TEST(EventInProfileSectionMatcher, in_profile_section_matcher)
 
     ASSERT_FALSE(matcher(DestroyProfileSectionEvent{.section_id = section_id}));
 }
-//! @test Check traits of @ref Kokkos::utils::callbacks::EventInRegionMatcher.
-TEST(EventInRegionMatcher, traits)
+//! @test Check traits of @ref Kokkos::utils::callbacks::EventRegionMatcher.
+TEST(EventRegionMatcher, traits)
 {
-    using matcher_t = EventInRegionMatcher<EventRegexMatcher>;
+    using matcher_t = EventRegionMatcher<EventRegexMatcher>;
 
     static_assert(Matcher     <matcher_t>);
     static_assert(MatcherFor  <matcher_t, EventTypeList>);
     static_assert(std::movable<matcher_t>);
 }
 
-//! @test Check the behavior of @ref Kokkos::utils::callbacks::EventInRegionMatcher.
-TEST(EventInRegionMatcher, in_region_matcher)
+//! @test Check the behavior of @ref Kokkos::utils::callbacks::EventRegionMatcher when we want to match events within a region.
+TEST(EventRegionMatcher, within_region_matcher)
 {
-    EventInRegionMatcher matcher(EventRegexMatcher{.regex = std::regex("buried-region")});
+    EventRegionMatcher matcher(EventRegexMatcher{.regex = std::regex("buried-region")});
 
     ASSERT_FALSE(matcher(PushRegionEvent{.name = "not-the-one-we-want"}));
 
@@ -142,6 +142,30 @@ TEST(EventInRegionMatcher, in_region_matcher)
     ASSERT_TRUE(matcher(PopRegionEvent{}));
 
     ASSERT_FALSE(matcher(PopRegionEvent{}));
+}
+
+//! @test Check the behavior of @ref Kokkos::utils::callbacks::EventRegionMatcher when we want to match the opening and closing events.
+TEST(EventRegionMatcher, boundary_region_matcher)
+{
+    EventRegionMatcher<EventNameMatcher, true> matcher{{"buried-region"}};
+
+    ASSERT_FALSE(matcher(PushRegionEvent{.name = "not-the-one-we-want"}));
+
+    ASSERT_FALSE(matcher(AllocateDataEvent{}));
+
+    ASSERT_TRUE(matcher(PushRegionEvent{.name = "buried-region"}));
+
+    ASSERT_FALSE(matcher(AllocateDataEvent{}));
+
+    ASSERT_FALSE(matcher(PushRegionEvent{.name = "nested-region"}));
+
+    ASSERT_FALSE(matcher(AllocateDataEvent{}));
+
+    ASSERT_FALSE(matcher(PopRegionEvent{}));
+
+    ASSERT_TRUE(matcher(PopRegionEvent{}));
+
+    ASSERT_FALSE(matcher(BeginFenceEvent{}));
 }
 
 //! @test Check traits of @ref Kokkos::utils::callbacks::AnyEventMatcher.


### PR DESCRIPTION
## Summary

This PR:
- renames `Event[In]RegionMatcher` to `EventRegionMatcher`
- allows it to either match the events *strictly within* the region **or** the opening/closing events

## Related to

- followup of #48
