### PR TITLE
timer(events): cuda/hip event must be wrapper in a `unique_ptr`

### DIFF
--- a/include/kokkos-utils/timer/Cuda/Event.hpp
+++ b/include/kokkos-utils/timer/Cuda/Event.hpp
@@ -6,18 +6,36 @@
 namespace Kokkos::utils::timer
 {
 
+/**
+ * @brief Specialization for @c Kokkos::Cuda that uses @c cudaEvent_t.
+ *
+ * @note It must properly manage @ref event.
+ */
 template <>
 struct Event<Kokkos::Cuda>
 {
-    using impl_event_t = cudaEvent_t;
+    //! To be used for the custom deletor of @ref event.
+    struct Deletor
+    {
+        void operator()(CUevent_st* ptr) const {
+            KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventDestroy(ptr));
+        }
+    };
 
-    impl_event_t event = nullptr;
+    using impl_event_t    = cudaEvent_t;
+    using event_storage_t = std::unique_ptr<CUevent_st, Deletor>;
 
-    Event() { KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventCreate(&event)); }
+    static_assert(std::same_as<typename event_storage_t::pointer, impl_event_t>);
 
-    ~Event() { KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventDestroy(event)); }
+    event_storage_t event = nullptr;
 
-    void record(const Kokkos::Cuda& space) { KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventRecord(event, space.cuda_stream())); }
+    Event() {
+        impl_event_t tmp = nullptr;
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventCreate(&tmp));
+        event.reset(tmp);
+    }
+
+    void record(const Kokkos::Cuda& space) { KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventRecord(event.get(), space.cuda_stream())); }
 
     template <typename Duration = milliseconds>
     Duration duration(Event& other) {
@@ -32,11 +50,11 @@ private:
      */
     float elapsed(Event& other)
     {
-        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventSynchronize(other.event));
-        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventSynchronize(event));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventSynchronize(other.event.get()));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventSynchronize(event.get()));
 
         float elapsed_time;
-        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventElapsedTime(&elapsed_time, event, other.event));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventElapsedTime(&elapsed_time, event.get(), other.event.get()));
 
         return elapsed_time;
     }

--- a/include/kokkos-utils/timer/HIP/Event.hpp
+++ b/include/kokkos-utils/timer/HIP/Event.hpp
@@ -6,18 +6,36 @@
 namespace Kokkos::utils::timer
 {
 
+/**
+ * @brief Specialization for @c Kokkos::HIP that uses @c hipEvent_t.
+ *
+ * @note It must properly manage @ref event.
+ */
 template <>
 struct Event<Kokkos::HIP>
 {
-    using impl_event_t = hipEvent_t;
+    //! To be used for the custom deletor of @ref event.
+    struct Deletor
+    {
+        void operator()(ihipEvent_t* ptr) const {
+            KOKKOS_IMPL_HIP_SAFE_CALL(hipEventDestroy(ptr));
+        }
+    };
 
-    impl_event_t event = nullptr;
+    using impl_event_t    = hipEvent_t;
+    using event_storage_t = std::unique_ptr<ihipEvent_t, Deletor>;
 
-    Event() { KOKKOS_IMPL_HIP_SAFE_CALL(hipEventCreate(&event)); }
+    static_assert(std::same_as<typename event_storage_t::pointer, impl_event_t>);
 
-    ~Event() { KOKKOS_IMPL_HIP_SAFE_CALL(hipEventDestroy(event)); }
+    event_storage_t event = nullptr;
 
-    void record(const Kokkos::HIP& space) { KOKKOS_IMPL_HIP_SAFE_CALL(hipEventRecord(event, space.hip_stream())); }
+    Event() {
+        impl_event_t tmp = nullptr;
+        KOKKOS_IMPL_HIP_SAFE_CALL(hipEventCreate(&tmp));
+        event.reset(tmp);
+    }
+
+    void record(const Kokkos::HIP& space) { KOKKOS_IMPL_HIP_SAFE_CALL(hipEventRecord(event.get(), space.hip_stream())); }
 
     template <typename Duration = milliseconds>
     Duration duration(Event& other) {
@@ -32,11 +50,11 @@ private:
      */
     float elapsed(Event& other)
     {
-        KOKKOS_IMPL_HIP_SAFE_CALL(hipEventSynchronize(other.event));
-        KOKKOS_IMPL_HIP_SAFE_CALL(hipEventSynchronize(event));
+        KOKKOS_IMPL_HIP_SAFE_CALL(hipEventSynchronize(other.event.get()));
+        KOKKOS_IMPL_HIP_SAFE_CALL(hipEventSynchronize(event.get()));
 
         float elapsed_time;
-        KOKKOS_IMPL_HIP_SAFE_CALL(hipEventElapsedTime(&elapsed_time, event, other.event));
+        KOKKOS_IMPL_HIP_SAFE_CALL(hipEventElapsedTime(&elapsed_time, event.get(), other.event.get()));
 
         return elapsed_time;
     }

--- a/tests/timer/test_Event.cpp
+++ b/tests/timer/test_Event.cpp
@@ -70,4 +70,39 @@ TEST(Event, duration)
     ASSERT_GE(begin.duration<milliseconds>(end).count(), 0.);
 }
 
+//! @test Ensure that @ref Kokkos::utils::timer::Event can be destroyed while recording.
+TEST(Event, destroyed_while_recording)
+{
+    const execution_space exec {};
+
+    std::optional<event_t> event(std::in_place);
+
+    event->record(exec);
+
+    event.reset();
+}
+
+/**
+ * @test Ensure that @ref Kokkos::utils::timer::Event is properly movable.
+ *
+ * This is particularly critical for specializations for @c Kokkos::Cuda and @c Kokkos::HIP
+ * that need to properly deal with the management of @c cudaEvent_t and @c hipEvent_t, respectively.
+ */
+TEST(Event, movable)
+{
+    static_assert(std::movable<event_t>);
+
+    const execution_space exec {};
+
+    event_t begin, end;
+
+    begin.record(exec);
+
+    end.record(exec);
+
+    event_t moved(std::move(end)); // NOLINT(misc-const-correctness,performance-move-const-arg)
+
+    ASSERT_GE(begin.duration<milliseconds>(moved).count(), 0.);
+}
+
 } // namespace Kokkos::utils::tests::timer


### PR DESCRIPTION
## Summary

Our `Event` (timer) specializations for `Cuda` and `HIP` were unsafe.

Copying or moving a `Kokkos::utils::timer::Event<Kokkos::[Cuda|HIP]>` was unsafe and was leading to multiple calls of the destroy API on the same pointer.

## Related to

- spotted while working on #43 
