### PR TITLE
ci(hip): run tests with our self-hosted runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
                     - backend        : HIP
                       compiler_family: rocm
                       base_image     : rocm/dev-ubuntu-24.04:6.4
+                      tag_suffix     : -6.4
                       platforms      : linux/amd64
                       kokkos_arch    : AMD_GFX906
                     - backend        : OpenMP
@@ -135,20 +136,20 @@ jobs:
                 include:
                     - backend        : Cuda
                       compiler_family: gcc
-                      run_tests      : true
                       runs_on        : [self-hosted, linux, amd64, docker, cuda, blackwell120]
                       tag_suffix     : -12.9.0
                     - backend        : HIP
                       compiler_family: rocm
-                      run_tests      : false
+                      runs_on        : [self-hosted, linux, amd64, docker, rocm, amd_gfx906]
+                      tag_suffix     : -6.4
+                      options        : --device /dev/kfd --device /dev/dri
                     - backend        : OpenMP
                       compiler_family: gcc
-                      run_tests      : true
                     - backend        : OpenMP
                       compiler_family: clang
-                      run_tests      : true
         container:
             image: ${{ needs.set-vars.outputs.CI_IMAGE }}:${{ matrix.compiler_family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
+            options: --platform=linux/amd64 ${{ matrix.options }}
         steps:
             - uses: actions/checkout@v4
 
@@ -158,7 +159,6 @@ jobs:
                   cmake --build --preset=${{ matrix.compiler_family }}-${{ matrix.backend }} -j$(($(nproc) > 4 ? 4 : $(nproc)))
 
             - name: Test.
-              if  : ${{ matrix.run_tests }}
               run : |
                   ctest --preset=${{ matrix.compiler_family }}-${{ matrix.backend }}
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -125,6 +125,11 @@
             "name"            : "gcc-Cuda",
             "configurePreset" : "gcc-Cuda",
             "inherits"        : "default"
+        },
+        {
+            "name"            : "rocm-HIP",
+            "configurePreset" : "rocm-HIP",
+            "inherits"        : "default"
         }
     ]
 }


### PR DESCRIPTION
## Summary

Enable `HIP` testing with our self-hosted runner.

