### PR TITLE
callbacks(matchers): add "event is on a particular execution space instance" matcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ target_sources(
             include/kokkos-utils/callbacks/EventBeginEndEventIdMatcher.hpp
             include/kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp
             include/kokkos-utils/callbacks/EventNameMatcher.hpp
+            include/kokkos-utils/callbacks/EventOnExecMatcher.hpp
             include/kokkos-utils/callbacks/EventRegexMatcher.hpp
             include/kokkos-utils/callbacks/EventRegionMatcher.hpp
             include/kokkos-utils/callbacks/EventTypeMatcher.hpp

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -39,7 +39,7 @@ get_target_property(KokkosUtils_TARGET_FILES_FOR_DOC kokkosutils HEADER_SET_${Ko
 get_property(KokkosUtils_FILES_FOR_DOC GLOBAL PROPERTY KokkosUtils_FILES_FOR_DOC)
 
 include(${CMAKE_SOURCE_DIR}/cmake/functions/list.cmake)
-check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 27)
+check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 28)
 check_list_length(KokkosUtils_FILES_FOR_DOC        19)
 
 #---- Add Doxygen as a target.

--- a/include/kokkos-utils/callbacks/EventOnExecMatcher.hpp
+++ b/include/kokkos-utils/callbacks/EventOnExecMatcher.hpp
@@ -1,0 +1,30 @@
+#ifndef KOKKOS_UTILS_CALLBACKS_EVENTONEXECMATCHER_HPP
+#define KOKKOS_UTILS_CALLBACKS_EVENTONEXECMATCHER_HPP
+
+#include "kokkos-utils/callbacks/Events.hpp"
+#include "kokkos-utils/concepts/ExecutionSpace.hpp"
+
+namespace Kokkos::utils::callbacks
+{
+
+//! Match an event whose @c dev_id is the same as the one of @ref exec.
+template <Matcher MatcherType, Kokkos::utils::concepts::ExecutionSpace Exec>
+struct EventOnExecMatcher
+{
+    template <OnDeviceEvent EventType>
+    bool operator()(const EventType& event)
+    {
+        if(event.dev_id == dev_id)
+            return matcher(event);
+        else
+            return false;
+    }
+
+    MatcherType matcher;
+    Exec exec;
+    uint32_t dev_id = Kokkos::Tools::Experimental::device_id(exec);
+};
+
+} // namespace Kokkos::utils::callbacks
+
+#endif // KOKKOS_UTILS_CALLBACKS_EVENTONEXECMATCHER_HPP

--- a/include/kokkos-utils/callbacks/Events.hpp
+++ b/include/kokkos-utils/callbacks/Events.hpp
@@ -264,6 +264,12 @@ concept NamedEvent =
 //! Concept to constrain any event type that is one of the given event types.
 template <typename T, typename... EventTypes>
 concept EventOneOf = impl::type_list_contains_v<T, EventTypes...>;
+
+//! Concept to constraint any event that can happens on a given @c dev_id.
+template <typename EventType>
+concept OnDeviceEvent = Event<EventType> && requires (EventType& event) {
+    {event.dev_id} -> std::same_as<uint32_t&>;
+};
 ///@}
 
 //! @name Stream operators.

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -7,6 +7,7 @@
 #include "kokkos-utils/callbacks/EventBeginEndEventIdMatcher.hpp"
 #include "kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventNameMatcher.hpp"
+#include "kokkos-utils/callbacks/EventOnExecMatcher.hpp"
 #include "kokkos-utils/callbacks/EventRegexMatcher.hpp"
 #include "kokkos-utils/callbacks/EventRegionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventTypeMatcher.hpp"
@@ -227,6 +228,38 @@ TEST(EventBeginEndEventIdMatcher, operator_parentheses)
     ASSERT_TRUE (matcher(BeginParallelForEvent{.name = "example-pfor", .event_id = 666}));
     ASSERT_FALSE(matcher(EndParallelForEvent  {.event_id = 42}));
     ASSERT_TRUE (matcher(EndParallelForEvent  {.event_id = 666}));
+}
+
+//! @test Check traits of @ref Kokkos::utils::callbacks::EventOnExecMatcher.
+TEST(EventOnExecMatcher, traits)
+{
+    using matcher_t = EventOnExecMatcher<EventRegexMatcher, execution_space>;
+
+    using on_device_event_type_list_t = Kokkos::Impl::type_list<
+        BeginParallelForEvent,
+        BeginParallelReduceEvent,
+        BeginParallelScanEvent,
+        BeginFenceEvent
+    >;
+
+    static_assert(Matcher     <matcher_t>);
+    static_assert(std::same_as<matcher_event_type_list_t<matcher_t>, on_device_event_type_list_t>);
+    static_assert(std::movable<matcher_t>);
+}
+
+//! @test Check the behavior of @ref Kokkos::utils::callbacks::EventOnExecMatcher.
+TEST(EventOnExecMatcher, operator_parentheses)
+{
+    const auto execs = Kokkos::Experimental::partition_space(execution_space{}, 1,1);
+
+    const auto dev_id_0 = Kokkos::Tools::Experimental::device_id(execs.at(0));
+    const auto dev_id_1 = Kokkos::Tools::Experimental::device_id(execs.at(1));
+
+    EventOnExecMatcher<EventNameMatcher, execution_space> matcher {.matcher = EventNameMatcher("runs-on-device"), .exec = execs.at(0)};
+
+    ASSERT_EQ   (matcher(BeginParallelForEvent{.name = "runs-on-device", .dev_id = dev_id_1}), dev_id_0 == dev_id_1);
+    ASSERT_FALSE(matcher(BeginParallelForEvent{.name = "does-not-match", .dev_id = dev_id_0}));
+    ASSERT_TRUE (matcher(BeginParallelForEvent{.name = "runs-on-device", .dev_id = dev_id_0}));
 }
 
 } // namespace Kokkos::utils::tests::callbacks


### PR DESCRIPTION
## Summary

This will useful in #43 to filter events based on whether they are enqueued on a particular "device".

## Related to

- #43 
