### PR TITLE
tests(doxygen): check that the generated tag file is valid

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,8 +186,11 @@ jobs:
                   cmake -S .    --preset=gcc-OpenMP --warn-uninitialized -Werror=dev
                   cmake --build --preset=gcc-OpenMP --target=docs
 
-            - name: Upload Pages artifacts.
-              uses: actions/upload-pages-artifact@v3
+            - name: Check tag file.
+              run : |
+                  python3 tests/check_tag_file.py --tag-file=$PWD/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
+
+            - uses: actions/upload-pages-artifact@v3
               with:
                   path: build-with-gcc-OpenMP/docs/html
 

--- a/include/kokkos-utils/timer/Cuda/Event.hpp
+++ b/include/kokkos-utils/timer/Cuda/Event.hpp
@@ -14,8 +14,8 @@ namespace Kokkos::utils::timer
 template <>
 struct Event<Kokkos::Cuda>
 {
-    //! To be used for the custom deletor of @ref event.
-    struct Deletor
+    //! To be used for the custom deleter of @ref event.
+    struct EventDeleter
     {
         void operator()(CUevent_st* ptr) const {
             KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventDestroy(ptr));
@@ -23,7 +23,7 @@ struct Event<Kokkos::Cuda>
     };
 
     using impl_event_t    = cudaEvent_t;
-    using event_storage_t = std::unique_ptr<CUevent_st, Deletor>;
+    using event_storage_t = std::unique_ptr<CUevent_st, EventDeleter>;
 
     static_assert(std::same_as<typename event_storage_t::pointer, impl_event_t>);
 

--- a/include/kokkos-utils/timer/HIP/Event.hpp
+++ b/include/kokkos-utils/timer/HIP/Event.hpp
@@ -14,8 +14,8 @@ namespace Kokkos::utils::timer
 template <>
 struct Event<Kokkos::HIP>
 {
-    //! To be used for the custom deletor of @ref event.
-    struct Deletor
+    //! To be used for the custom deleter of @ref event.
+    struct EventDeleter
     {
         void operator()(ihipEvent_t* ptr) const {
             KOKKOS_IMPL_HIP_SAFE_CALL(hipEventDestroy(ptr));
@@ -23,7 +23,7 @@ struct Event<Kokkos::HIP>
     };
 
     using impl_event_t    = hipEvent_t;
-    using event_storage_t = std::unique_ptr<ihipEvent_t, Deletor>;
+    using event_storage_t = std::unique_ptr<ihipEvent_t, EventDeleter>;
 
     static_assert(std::same_as<typename event_storage_t::pointer, impl_event_t>);
 

--- a/tests/check_tag_file.py
+++ b/tests/check_tag_file.py
@@ -1,0 +1,74 @@
+import argparse
+import fileinput
+import logging
+import os
+import pathlib
+import re
+import subprocess
+import tempfile
+
+import typeguard
+
+SOURCE_CODE_HEADER = \
+"""
+void useless();
+"""
+
+@typeguard.typechecked
+def parse_args() -> argparse.Namespace:
+    """
+    Parse CLI arguments.
+    """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--tag-file', type = pathlib.Path, required = True)
+    parser.add_argument('--doxygen',  type = pathlib.Path, required = False, default = pathlib.Path(os.environ.get('Doxygen_ROOT')) / 'bin' / 'doxygen')
+
+    return parser.parse_args()
+
+@typeguard.typechecked
+def check_tag_file(*, file : pathlib.Path, doxygen : pathlib.Path) -> None:
+    """
+    Check that the `Doxygen` tag `file` is valid.
+    """
+    logging.info(f"Checking that the tag file {file} is valid.")
+
+    with tempfile.TemporaryDirectory(delete = True) as tmpdir_str:
+        tmpdir = pathlib.Path(tmpdir_str)
+
+        hpp = tmpdir / 'test.hpp'
+        hpp.write_text(SOURCE_CODE_HEADER)
+
+        doxyfile = tmpdir / 'doxygen'
+        subprocess.check_call([doxygen, '-g', doxyfile])
+
+        replacing = {
+            r'WARN_AS_ERROR[ ]+=[ ]+NO' : [False, 'WARN_AS_ERROR=YES'],
+            r'INPUT[ ]+='               : [False, f"INPUT={hpp}"],
+            r'TAGFILES[ ]+='            : [False, f'TAGFILES={file}'],
+        }
+
+        with fileinput.input(doxyfile, inplace = True) as f:
+            for line in f:
+                for k, v in replacing.items():
+                    if v[0] is False:
+                        if re.match(k, line) is not None:
+                            v[0] = True
+                            line = v[1]
+                            break
+                print(line)
+
+        if any(v[0] is False for v in replacing.values()):
+            raise RuntimeError("Couldn't replace all the needed parameters.")
+
+        subprocess.check_call([doxygen, doxyfile], cwd = tmpdir)
+
+if __name__ == '__main__':
+
+    logging.basicConfig(level = logging.INFO)
+
+    args = parse_args()
+
+    logging.info(f"Received arguments: {args}")
+
+    check_tag_file(file = args.tag_file, doxygen = args.doxygen)


### PR DESCRIPTION
## Summary

The generated `Doxygen` tag file is invalid, causing downstream projects to fail their own documentation.

I could reproduce it, see:
- https://github.com/doxygen/doxygen/issues/11569

## Description

Typical error:
```bash
Warn for undocumented namespaces...
Computing class relations...
Add enum values to enums...
Searching for member function documentation...
/workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag:1494: error: no uniquely matching class member found for 
  void Kokkos::utils::timer::Event< Kokkos::Cuda >::Deletor::operator()(CUevent_st *ptr) const
Possible candidates:
  'constexpr bool Kokkos::utils::callbacks::AnyEventMatcher::operator()(const EventType &) const' at line 1246 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventBeginEndEventIdMatcher< Matcher MatcherBeginEventType, BeginEvent BeginEventType, EndEvent EndEventType >::operator()(const BeginEventType &event)' at line 1852 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventBeginEndEventIdMatcher< Matcher MatcherBeginEventType, BeginEvent BeginEventType, EndEvent EndEventType >::operator()(const EndEventType &event) const' at line 1859 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventInProfileSectionMatcher< typename MatcherType >::operator()(const CreateProfileSectionEvent &event)' at line 1892 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventInProfileSectionMatcher< typename MatcherType >::operator()(const StartProfileSectionEvent &event)' at line 1899 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventInProfileSectionMatcher< typename MatcherType >::operator()(const StopProfileSectionEvent &event)' at line 1906 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventInProfileSectionMatcher< typename MatcherType >::operator()(const EventType &) const' at line 1913 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventNameMatcher::operator()(const EventType &event) const' at line 1952 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventNameMatcher::operator()(const EventType &event) const' at line 1959 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventOnExecMatcher< Matcher MatcherType, Kokkos::utils::concepts::ExecutionSpace Exec >::operator()(const EventType &event)' at line 1979 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventRegexMatcher::operator()(const EventType &event) const' at line 2011 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventRegexMatcher::operator()(const EventType &event) const' at line 2018 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventRegionMatcher< typename MatcherType, bool TrueOnBoundary >::operator()(const PushRegionEvent &event)' at line 2038 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventRegionMatcher< typename MatcherType, bool TrueOnBoundary >::operator()(const PopRegionEvent &)' at line 2045 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventRegionMatcher< typename MatcherType, bool TrueOnBoundary >::operator()(const EventType &) const' at line 2052 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'bool Kokkos::utils::callbacks::EventTypeMatcher< Matcher MatcherType, Event... EventTypes >::operator()(const EventType &event)' at line 2242 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'KOKKOS_FUNCTION void Kokkos::utils::tests::atomics::InsertMinTest< concepts::View view_t >::operator()(const T trial) const' at line 2279 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'virtual void Kokkos::utils::callbacks::impl::ListenerConceptCallOperator< Event EventType >::operator()(const EventType &event) const=0' at line 2364 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'void Kokkos::utils::callbacks::impl::ListenerModelCallOperator< Event EventType, typename ListenerModel >::operator()(const EventType &event) const override' at line 2432 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'KOKKOS_FUNCTION void Kokkos::utils::tests::callbacks::MyWorkload::MyFunctor::operator()(const T) const' at line 2624 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'void Kokkos::utils::callbacks::RecorderListener< MatcherType, EventTypes... >::operator()(const EventType &event)' at line 2742 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag
  'void Kokkos::utils::tests::callbacks::TesterListener< Event... EventTypes >::operator()(const EventType &event)' at line 2843 of file /workspaces/kokkos-utils/build-with-gcc-OpenMP/docs/html/kokkos-utils.tag (warning treated as error, aborting now)
Exiting...
```

The fact that the `Deletor` also has an `event` underneath is suspicious.
![image](https://github.com/user-attachments/assets/ff032757-82a0-44fc-b4bf-2bd2a22e5243)
