### PR TITLE
feat(timer): add specialization for `void`

### DIFF
--- a/include/kokkos-utils/timer/Cuda/Event.hpp
+++ b/include/kokkos-utils/timer/Cuda/Event.hpp
@@ -35,7 +35,8 @@ struct Event<Kokkos::Cuda>
         event.reset(tmp);
     }
 
-    void record(const Kokkos::Cuda& space) { KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventRecord(event.get(), space.cuda_stream())); }
+    //! Record this event in the execution space instance @p exec.
+    void record(const Kokkos::Cuda& exec) { KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventRecord(event.get(), exec.cuda_stream())); }
 
     template <typename Duration = milliseconds>
     Duration duration(Event& other) {

--- a/include/kokkos-utils/timer/Event.hpp
+++ b/include/kokkos-utils/timer/Event.hpp
@@ -11,28 +11,40 @@ namespace Kokkos::utils::timer
 /**
  * @brief Event.
  *
- * This primary template is implemented using @c std::chrono::steady_clock::time_point.
+ * The instantiation for the type @c void concerns the case in which
+ * the event is not related to a particular execution space. It is
+ * implemented by using @c std::chrono::steady_clock::time_point.
  *
- * Using a CPU timer to time device kernel execution requires host-device
- * synchronization barriers.
+ * The instantiations for execution spaces default to an implementation
+ * that is identical to the implementation for the instantiation for the
+ * type @c void, except that the member function @c record takes an
+ * execution space instance as argument. This argument is unused.
  *
- * This class has specialisations for device backends:
+ * The specializations for device execution spaces:
  *     - @c Cuda (@ref timer/Cuda/Event.hpp),
  *     - @c HIP (@ref timer/HIP/Event.hpp),
- * which use @c Cuda and @c HIP events, respectively, and require
- * no explicit host-device synchronization barriers. Note that the
+ * use the @c Cuda and @c HIP event management API. Note that the
  * @c cudaEventSynchronize and @c hipEventSynchronize functions used by
- * these specialisations do involve a host-device synchronization barrier.
+ * these specializations involve host-device synchronization.
  */
-template <Kokkos::utils::concepts::ExecutionSpace Exec>
+template <typename T>
+requires Kokkos::utils::concepts::ExecutionSpace<T> || std::is_void_v<T>
 struct Event
 {
     using impl_event_t = std::chrono::steady_clock::time_point;
 
     impl_event_t event;
 
-    //! Record this event in the execution space @p exec.
-    void record(const Exec& /* exec */) {
+    //! Record this event.
+    template <typename U = T>
+    requires std::is_void_v<U>
+    void record() {
+        event = std::chrono::steady_clock::now();
+    }
+
+    template <typename Exec = T>
+    requires Kokkos::utils::concepts::ExecutionSpace<Exec>
+    void record(const Exec&) {
         event = std::chrono::steady_clock::now();
     }
 

--- a/include/kokkos-utils/timer/HIP/Event.hpp
+++ b/include/kokkos-utils/timer/HIP/Event.hpp
@@ -35,7 +35,8 @@ struct Event<Kokkos::HIP>
         event.reset(tmp);
     }
 
-    void record(const Kokkos::HIP& space) { KOKKOS_IMPL_HIP_SAFE_CALL(hipEventRecord(event.get(), space.hip_stream())); }
+    //! Record this event in the execution space instance @p exec.
+    void record(const Kokkos::HIP& exec) { KOKKOS_IMPL_HIP_SAFE_CALL(hipEventRecord(event.get(), exec.hip_stream())); }
 
     template <typename Duration = milliseconds>
     Duration duration(Event& other) {

--- a/include/kokkos-utils/timer/Timer.hpp
+++ b/include/kokkos-utils/timer/Timer.hpp
@@ -12,29 +12,16 @@ namespace Kokkos::utils::timer
  * This class uses @ref Event to create, destroy, record, and compute
  * the elapsed time between events.
  */
-template <Kokkos::utils::concepts::ExecutionSpace Exec>
+template <typename T>
+requires Kokkos::utils::concepts::ExecutionSpace<T> || std::is_void_v<T>
 class Timer
 {
 public:
-    using event_t = Event<Exec>;
+    using event_t = Event<T>;
 
 public:
-    //! Start the timer.
-    void start(const Exec& exec)
-    {
-        tick.record(exec);
-        started = true;
-    }
-
-    //! Stop the timer.
-    void stop(const Exec& exec)
-    {
-        tock.record(exec);
-        stopped = true;
-    }
-
     //! Returns @c true if @ref start and @ref stop have been called.
-    bool is_valid() const { return started && stopped; }
+    bool is_valid() const { return tick.has_value() && tock.has_value(); }
 
     /**
      * Get a @c std::chrono::duration object representing the elapsed time.
@@ -43,11 +30,44 @@ public:
      *       whose device specializations are not @c const.
      */
     template <typename Duration = milliseconds>
-    Duration duration() { return tick.template duration<Duration>(tock); }
+    Duration duration() { return tick->template duration<Duration>(*tock); }
+
+    //! Start the timer.
+    template <typename U = T>
+    requires std::is_void_v<U>
+    void start()
+    {
+        if(! tick.has_value()) tick.emplace();
+        tick->record();
+    }
+
+    template <typename Exec = T>
+    requires Kokkos::utils::concepts::ExecutionSpace<Exec>
+    void start(const Exec& exec)
+    {
+        if(! tick.has_value()) tick.emplace();
+        tick->record(exec);
+    }
+
+    //! Stop the timer.
+    template <typename U = T>
+    requires std::is_void_v<U>
+    void stop()
+    {
+        if(! tock.has_value()) tock.emplace();
+        tock->record();
+    }
+
+    template <typename Exec = T>
+    requires Kokkos::utils::concepts::ExecutionSpace<Exec>
+    void stop(const Exec& exec)
+    {
+        if(! tock.has_value()) tock.emplace();
+        tock->record(exec);
+    }
 
 private:
-    event_t tick {},         tock {};
-    bool    started = false, stopped = false;
+    std::optional<event_t> tick = std::nullopt, tock = std::nullopt;
 };
 
 } // namespace Kokkos::utils::timer

--- a/tests/timer/test_Event.cpp
+++ b/tests/timer/test_Event.cpp
@@ -23,21 +23,41 @@ namespace Kokkos::utils::tests::timer
 
 using namespace Kokkos::utils::timer;
 
-using event_t = Event<execution_space>;
+template <typename T>
+struct EventTest : public ::testing::Test
+{
+public:
+    void SetUp() override {
+        this->exec = Kokkos::Experimental::partition_space(execution_space{}, 1)[0];
+    }
+
+protected:
+    execution_space exec {};
+};
+
+using EventTypes = ::testing::Types<
+    Event<void>,
+    Event<execution_space>
+>;
+
+TYPED_TEST_SUITE(EventTest, EventTypes);
 
 //! @test Check the type of the event used by the primary template and the device specializations.
-TEST(Event, impl_event_type)
+TYPED_TEST(EventTest, impl_event_type)
 {
-    using expt_impl_event_t =
+    using expt_impl_event_t = std::conditional_t<
+        std::same_as<TypeParam, Event<void>>,
+        std::chrono::steady_clock::time_point,
 #if defined(KOKKOS_ENABLE_CUDA)
-    cudaEvent_t;
+        cudaEvent_t
 #elif defined(KOKKOS_ENABLE_HIP)
-    hipEvent_t;
+        hipEvent_t
 #else
-    std::chrono::steady_clock::time_point;
+    std::chrono::steady_clock::time_point
 #endif
+    >;
 
-    static_assert(std::same_as<typename event_t::impl_event_t, expt_impl_event_t>);
+    static_assert(std::same_as<typename TypeParam::impl_event_t, expt_impl_event_t>);
 }
 
 //! @test Check the traits of the helper types @ref Kokkos::utils::timer::milliseconds and @ref Kokkos::utils::timer::seconds.
@@ -57,27 +77,34 @@ TEST(Event, duration_instances)
 }
 
 //! @test Basic test of @ref Kokkos::utils::timer::Event::duration.
-TEST(Event, duration)
+TYPED_TEST(EventTest, duration)
 {
-    const execution_space exec {};
+    TypeParam begin, end;
 
-    event_t begin, end;
+    if constexpr (std::same_as<TypeParam, void>)
+    {
+        begin.record();
+        end.record();
+    }
+    else
+    {
+        begin.record(this->exec);
+        end.record(this->exec);
+    }
 
-    begin.record(exec);
-
-    end.record(exec);
-
-    ASSERT_GE(begin.duration<milliseconds>(end).count(), 0.);
+    ASSERT_GE(begin.template duration<milliseconds>(end).count(), 0.);
 }
 
 //! @test Ensure that @ref Kokkos::utils::timer::Event can be destroyed while recording.
-TEST(Event, destroyed_while_recording)
+TYPED_TEST(EventTest, destroyed_while_recording)
 {
-    const execution_space exec {};
+    std::optional<TypeParam> event(std::in_place);
 
-    std::optional<event_t> event(std::in_place);
-
-    event->record(exec);
+    if constexpr (std::same_as<TypeParam, void>) {
+        event->record();
+    } else {
+        event->record(this->exec);
+    }
 
     event.reset();
 }
@@ -88,21 +115,26 @@ TEST(Event, destroyed_while_recording)
  * This is particularly critical for specializations for @c Kokkos::Cuda and @c Kokkos::HIP
  * that need to properly deal with the management of @c cudaEvent_t and @c hipEvent_t, respectively.
  */
-TEST(Event, movable)
+TYPED_TEST(EventTest, movable)
 {
-    static_assert(std::movable<event_t>);
+    static_assert(std::movable<TypeParam>);
 
-    const execution_space exec {};
+    TypeParam begin, end;
 
-    event_t begin, end;
+    if constexpr (std::same_as<TypeParam, void>)
+    {
+        begin.record();
+        end.record();
+    }
+    else
+    {
+        begin.record(this->exec);
+        end.record(this->exec);
+    }
 
-    begin.record(exec);
+    TypeParam moved(std::move(end)); // NOLINT(misc-const-correctness,performance-move-const-arg)
 
-    end.record(exec);
-
-    event_t moved(std::move(end)); // NOLINT(misc-const-correctness,performance-move-const-arg)
-
-    ASSERT_GE(begin.duration<milliseconds>(moved).count(), 0.);
+    ASSERT_GE(begin.template duration<milliseconds>(moved).count(), 0.);
 }
 
 } // namespace Kokkos::utils::tests::timer

--- a/tests/timer/test_Timer.cpp
+++ b/tests/timer/test_Timer.cpp
@@ -22,9 +22,8 @@ namespace Kokkos::utils::tests::timer
 
 using namespace Kokkos::utils::timer;
 
-using timer_t = Timer<execution_space>;
-
-class TimerTest : public ::testing::Test
+template <typename T>
+struct TimerTest : public ::testing::Test
 {
 public:
     void SetUp() override {
@@ -35,13 +34,20 @@ protected:
     execution_space exec {};
 };
 
+using TimerTypes = ::testing::Types<
+    Timer<void>,
+    Timer<execution_space>
+>;
+
+TYPED_TEST_SUITE(TimerTest, TimerTypes);
+
 /**
  * @test Check that @ref Kokkos::utils::timer::Timer reports it's invalid when neither @ref Kokkos::utils::timer::Timer::start
  *       nor @ref Kokkos::utils::timer::Timer::stop has been called.
  */
-TEST_F(TimerTest, invalid_if_not_started_and_not_stopped)
+TYPED_TEST(TimerTest, invalid_if_not_started_and_not_stopped)
 {
-    const timer_t timer;
+    const TypeParam timer;
     ASSERT_FALSE(timer.is_valid());
 }
 
@@ -49,10 +55,16 @@ TEST_F(TimerTest, invalid_if_not_started_and_not_stopped)
  * @test Check that @ref Kokkos::utils::timer::Timer reports it's invalid when @ref Kokkos::utils::timer::Timer::start has been called,
  *       but @ref Kokkos::utils::timer::Timer::stop has not.
  */
-TEST_F(TimerTest, invalid_if_not_stopped)
+TYPED_TEST(TimerTest, invalid_if_not_stopped)
 {
-    timer_t timer;
-    timer.start(this->exec);
+    TypeParam timer;
+
+    if constexpr (std::same_as<TypeParam, void>) {
+        timer.start();
+    } else {
+        timer.start(this->exec);
+    }
+
     ASSERT_FALSE(timer.is_valid());
 }
 
@@ -60,10 +72,16 @@ TEST_F(TimerTest, invalid_if_not_stopped)
  * @test Check that @ref Kokkos::utils::timer::Timer reports it's invalid when @ref Kokkos::utils::timer::Timer::start has not been called,
  *       but @ref Kokkos::utils::timer::Timer::stop has.
  */
-TEST_F(TimerTest, invalid_if_not_started)
+TYPED_TEST(TimerTest, invalid_if_not_started)
 {
-    timer_t timer;
-    timer.stop(this->exec);
+    TypeParam timer;
+
+    if constexpr (std::same_as<TypeParam, void>) {
+        timer.stop();
+    } else {
+        timer.stop(this->exec);
+    }
+
     ASSERT_FALSE(timer.is_valid());
 }
 
@@ -71,19 +89,33 @@ TEST_F(TimerTest, invalid_if_not_started)
  * @test Check that @ref Kokkos::utils::timer::Timer reports it's valid when @ref Kokkos::utils::timer::Timer::start and
  *       @ref Kokkos::utils::timer::Timer::stop have been called.
  */
-TEST_F(TimerTest, valid_if_started_and_stopped)
+TYPED_TEST(TimerTest, valid_if_started_and_stopped)
 {
-    timer_t timer;
-    timer.start(this->exec);
-    timer.stop (this->exec);
+    TypeParam timer;
+
+    if constexpr (std::same_as<TypeParam, void>)
+    {
+        timer.start();
+        timer.stop();
+    }
+    else
+    {
+        timer.start(this->exec);
+        timer.stop(this->exec);
+    }
+
     ASSERT_TRUE(timer.is_valid());
 }
+
+struct TimerExecutionSpaceTest : public TimerTest<execution_space> {
+    using timer_t = Timer<execution_space>;
+};
 
 /**
  * @test Check @ref Kokkos::utils::timer::Timer by verifying that the elapsed time is less
  *       than the time measured by a @c Kokkos::Timer wrapped outside of it.
  */
-TEST_F(TimerTest, start_stop_elapsed)
+TEST_F(TimerExecutionSpaceTest, start_stop_elapsed)
 {
     using view_t = Kokkos::View<double*, execution_space>;
 
@@ -113,31 +145,39 @@ TEST_F(TimerTest, start_stop_elapsed)
 }
 
 //! @test Check @ref Kokkos::utils::timer::Timer::duration.
-TEST_F(TimerTest, duration)
+TYPED_TEST(TimerTest, duration)
 {
-    timer_t timer;
+    TypeParam timer;
 
-    timer.start(this->exec);
+    if constexpr (std::same_as<TypeParam, void>) {
+        timer.start();
+    } else {
+        timer.start(this->exec);
+    }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    timer.stop(this->exec);
+    if constexpr (std::same_as<TypeParam, void>) {
+        timer.stop();
+    } else {
+        timer.stop(this->exec);
+    }
 
-    const double elapsed = timer.duration<milliseconds>().count();
+    const double elapsed = timer.template duration<milliseconds>().count();
 
     //! Check that the elapsed time is greater than the waiting time of 100 ms.
     ASSERT_GE(elapsed, 100.);
 
     //! Check the elapsed time in milliseconds.
-    const auto duration_ms = timer.duration<milliseconds>();
+    const auto duration_ms = timer.template duration<milliseconds>();
     ASSERT_NEAR(duration_ms.count(), elapsed, /* abs_error */ 1e-3);
 
     //! Check the elapsed time in microseconds.
-    const auto duration_us = timer.duration<microseconds>();
+    const auto duration_us = timer.template duration<microseconds>();
     ASSERT_NEAR(duration_us.count(), elapsed * 1e3, /* abs_error */ 1.);
 
     //! Check the elapsed time in seconds.
-    const auto duration_se = timer.duration<seconds>();
+    const auto duration_se = timer.template duration<seconds>();
     ASSERT_NEAR(duration_se.count(), elapsed / 1e3, /* abs_error */ 1e-6);
 
     //! Check consistency.
@@ -145,7 +185,7 @@ TEST_F(TimerTest, duration)
     ASSERT_LE(abs(duration_ms - duration_se), std::chrono::microseconds(1));
 
     //! Ensure the timer is effectively stopped.
-    ASSERT_EQ(duration_ms, (timer.duration<milliseconds>()));
+    ASSERT_EQ(duration_ms, (timer.template duration<milliseconds>()));
 }
 
 /**
@@ -166,7 +206,7 @@ TEST_F(TimerTest, duration)
  *
  * This test helps us ensure that for a "start -> stop -> start -> stop -> ..." sequence, our timer is fine.
  */
- TEST_F(TimerTest, reuse)
+TEST_F(TimerExecutionSpaceTest, reuse)
 {
     constexpr size_t nreps = 10;
 


### PR DESCRIPTION
This PR adds a specialisation of our timer that is not related to a particular execution space. As a result, the `record` function of this timer does not take an execution space instance as argument.

Related to:
- https://github.com/uliegecsm/kokkos-utils/pull/43
