### PR TITLE
callbacks(matchers): add event id matcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ target_sources(
             include/kokkos-utils/atomics/InsertOp.hpp
 
             include/kokkos-utils/callbacks/EventBeginEndEventIdMatcher.hpp
+            include/kokkos-utils/callbacks/EventIdMatcher.hpp
             include/kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp
             include/kokkos-utils/callbacks/EventNameMatcher.hpp
             include/kokkos-utils/callbacks/EventQueueMatcher.hpp

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -39,7 +39,7 @@ get_target_property(KokkosUtils_TARGET_FILES_FOR_DOC kokkosutils HEADER_SET_${Ko
 get_property(KokkosUtils_FILES_FOR_DOC GLOBAL PROPERTY KokkosUtils_FILES_FOR_DOC)
 
 include(${CMAKE_SOURCE_DIR}/cmake/functions/list.cmake)
-check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 28)
+check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 29)
 check_list_length(KokkosUtils_FILES_FOR_DOC        19)
 
 #---- Add Doxygen as a target.

--- a/include/kokkos-utils/callbacks/EventIdMatcher.hpp
+++ b/include/kokkos-utils/callbacks/EventIdMatcher.hpp
@@ -1,0 +1,27 @@
+#ifndef KOKKOS_UTILS_CALLBACKS_EVENTIDMATCHER_HPP
+#define KOKKOS_UTILS_CALLBACKS_EVENTIDMATCHER_HPP
+
+#include "kokkos-utils/callbacks/Events.hpp"
+#include "kokkos-utils/concepts/ExecutionSpace.hpp"
+
+namespace Kokkos::utils::callbacks
+{
+
+//! Match an event whose @c event_id is @ref event_id.
+struct EventIdMatcher
+{
+    using event_id_t = uint64_t;
+
+    static constexpr event_id_t invalid_event_id = Kokkos::Experimental::finite_max_v<event_id_t>;
+
+    template <IndexedEvent EventType>
+    bool operator()(const EventType& event) const {
+        return event.event_id == event_id;
+    }
+
+    event_id_t event_id = invalid_event_id;
+};
+
+} // namespace Kokkos::utils::callbacks
+
+#endif // KOKKOS_UTILS_CALLBACKS_EVENTIDMATCHER_HPP

--- a/include/kokkos-utils/callbacks/Events.hpp
+++ b/include/kokkos-utils/callbacks/Events.hpp
@@ -261,15 +261,22 @@ concept NamedEvent =
         { event.name } -> std::same_as<std::string&>;
     };
 
-//! Concept to constrain any event type that is one of the given event types.
-template <typename T, typename... EventTypes>
-concept EventOneOf = impl::type_list_contains_v<T, EventTypes...>;
+//! Concept to constrain any event type that has a member variable @c event_id.
+template <typename EventType>
+concept IndexedEvent = Event<EventType> && requires (EventType event) {
+    { event.event_id } -> std::same_as<uint64_t&>;
+};
 
 //! Concept to constrain any event type that has a member variable @c dev_id.
 template <typename EventType>
 concept EnqueuedEvent = Event<EventType> && requires (EventType event) {
     { event.dev_id } -> std::same_as<uint32_t&>;
 };
+
+//! Concept to constrain any event type that is one of the given event types.
+template <typename T, typename... EventTypes>
+concept EventOneOf = impl::type_list_contains_v<T, EventTypes...>;
+
 ///@}
 
 //! @name Stream operators.

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -5,6 +5,7 @@
 #include "kokkos-utils/impl/type_traits.hpp"
 
 #include "kokkos-utils/callbacks/EventBeginEndEventIdMatcher.hpp"
+#include "kokkos-utils/callbacks/EventIdMatcher.hpp"
 #include "kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventNameMatcher.hpp"
 #include "kokkos-utils/callbacks/EventQueueMatcher.hpp"
@@ -260,6 +261,32 @@ TEST(EventQueueMatcher, operator_parentheses)
     ASSERT_EQ   (matcher(BeginParallelForEvent{.name = "runs-on-device", .dev_id = dev_id_1}), dev_id_0 == dev_id_1);
     ASSERT_FALSE(matcher(BeginParallelForEvent{.name = "does-not-match", .dev_id = dev_id_0}));
     ASSERT_TRUE (matcher(BeginParallelForEvent{.name = "runs-on-device", .dev_id = dev_id_0}));
+}
+
+//! @test Check traits of @ref Kokkos::utils::callbacks::EventIdMatcher.
+TEST(EventIdMatcher, traits)
+{
+    using matcher_t = EventIdMatcher;
+
+    using indexed_event_type_list_t = Kokkos::Impl::type_list<
+        BeginParallelForEvent,    EndParallelForEvent,
+        BeginParallelReduceEvent, EndParallelReduceEvent,
+        BeginParallelScanEvent,   EndParallelScanEvent,
+        BeginFenceEvent,          EndFenceEvent
+    >;
+
+    static_assert(Matcher     <matcher_t>);
+    static_assert(std::same_as<matcher_event_type_list_t<matcher_t>, indexed_event_type_list_t>);
+    static_assert(std::movable<matcher_t>);
+}
+
+//! @test Check the behavior of @ref Kokkos::utils::callbacks::EventIdMatcher.
+TEST(EventIdMatcher, operator_parentheses)
+{
+    const EventIdMatcher matcher{.event_id = 42};
+
+    ASSERT_TRUE (matcher(BeginParallelForEvent{.event_id =  42}));
+    ASSERT_FALSE(matcher(BeginParallelForEvent{.event_id = 666}));
 }
 
 } // namespace Kokkos::utils::tests::callbacks


### PR DESCRIPTION
## Summary

This PR introduces (yet another) matcher that matches events based on their `event_id` field, if any.

## Related to

- extracted from #43
