### PR TITLE
callbacks(matcher): rename `EventOnExecMatcher` to `EventQueueMatcher`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ target_sources(
             include/kokkos-utils/callbacks/EventBeginEndEventIdMatcher.hpp
             include/kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp
             include/kokkos-utils/callbacks/EventNameMatcher.hpp
-            include/kokkos-utils/callbacks/EventOnExecMatcher.hpp
+            include/kokkos-utils/callbacks/EventQueueMatcher.hpp
             include/kokkos-utils/callbacks/EventRegexMatcher.hpp
             include/kokkos-utils/callbacks/EventRegionMatcher.hpp
             include/kokkos-utils/callbacks/EventTypeMatcher.hpp

--- a/include/kokkos-utils/callbacks/EventQueueMatcher.hpp
+++ b/include/kokkos-utils/callbacks/EventQueueMatcher.hpp
@@ -1,5 +1,5 @@
-#ifndef KOKKOS_UTILS_CALLBACKS_EVENTONEXECMATCHER_HPP
-#define KOKKOS_UTILS_CALLBACKS_EVENTONEXECMATCHER_HPP
+#ifndef KOKKOS_UTILS_CALLBACKS_EVENTQUEUEMATCHER_HPP
+#define KOKKOS_UTILS_CALLBACKS_EVENTQUEUEMATCHER_HPP
 
 #include "kokkos-utils/callbacks/Events.hpp"
 #include "kokkos-utils/concepts/ExecutionSpace.hpp"
@@ -9,9 +9,9 @@ namespace Kokkos::utils::callbacks
 
 //! Match an event whose @c dev_id is the same as the one of @ref exec.
 template <Matcher MatcherType, Kokkos::utils::concepts::ExecutionSpace Exec>
-struct EventOnExecMatcher
+struct EventQueueMatcher
 {
-    template <OnDeviceEvent EventType>
+    template <EnqueuedEvent EventType>
     bool operator()(const EventType& event)
     {
         if(event.dev_id == dev_id)
@@ -27,4 +27,4 @@ struct EventOnExecMatcher
 
 } // namespace Kokkos::utils::callbacks
 
-#endif // KOKKOS_UTILS_CALLBACKS_EVENTONEXECMATCHER_HPP
+#endif // KOKKOS_UTILS_CALLBACKS_EVENTQUEUEMATCHER_HPP

--- a/include/kokkos-utils/callbacks/Events.hpp
+++ b/include/kokkos-utils/callbacks/Events.hpp
@@ -265,10 +265,10 @@ concept NamedEvent =
 template <typename T, typename... EventTypes>
 concept EventOneOf = impl::type_list_contains_v<T, EventTypes...>;
 
-//! Concept to constraint any event that can happens on a given @c dev_id.
+//! Concept to constrain any event type that has a member variable @c dev_id.
 template <typename EventType>
-concept OnDeviceEvent = Event<EventType> && requires (EventType& event) {
-    {event.dev_id} -> std::same_as<uint32_t&>;
+concept EnqueuedEvent = Event<EventType> && requires (EventType event) {
+    { event.dev_id } -> std::same_as<uint32_t&>;
 };
 ///@}
 

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -7,7 +7,7 @@
 #include "kokkos-utils/callbacks/EventBeginEndEventIdMatcher.hpp"
 #include "kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventNameMatcher.hpp"
-#include "kokkos-utils/callbacks/EventOnExecMatcher.hpp"
+#include "kokkos-utils/callbacks/EventQueueMatcher.hpp"
 #include "kokkos-utils/callbacks/EventRegexMatcher.hpp"
 #include "kokkos-utils/callbacks/EventRegionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventTypeMatcher.hpp"
@@ -230,12 +230,12 @@ TEST(EventBeginEndEventIdMatcher, operator_parentheses)
     ASSERT_TRUE (matcher(EndParallelForEvent  {.event_id = 666}));
 }
 
-//! @test Check traits of @ref Kokkos::utils::callbacks::EventOnExecMatcher.
-TEST(EventOnExecMatcher, traits)
+//! @test Check traits of @ref Kokkos::utils::callbacks::EventQueueMatcher.
+TEST(EventQueueMatcher, traits)
 {
-    using matcher_t = EventOnExecMatcher<EventRegexMatcher, execution_space>;
+    using matcher_t = EventQueueMatcher<EventRegexMatcher, execution_space>;
 
-    using on_device_event_type_list_t = Kokkos::Impl::type_list<
+    using enqueued_event_type_list_t = Kokkos::Impl::type_list<
         BeginParallelForEvent,
         BeginParallelReduceEvent,
         BeginParallelScanEvent,
@@ -243,19 +243,19 @@ TEST(EventOnExecMatcher, traits)
     >;
 
     static_assert(Matcher     <matcher_t>);
-    static_assert(std::same_as<matcher_event_type_list_t<matcher_t>, on_device_event_type_list_t>);
+    static_assert(std::same_as<matcher_event_type_list_t<matcher_t>, enqueued_event_type_list_t>);
     static_assert(std::movable<matcher_t>);
 }
 
-//! @test Check the behavior of @ref Kokkos::utils::callbacks::EventOnExecMatcher.
-TEST(EventOnExecMatcher, operator_parentheses)
+//! @test Check the behavior of @ref Kokkos::utils::callbacks::EventQueueMatcher.
+TEST(EventQueueMatcher, operator_parentheses)
 {
     const auto execs = Kokkos::Experimental::partition_space(execution_space{}, 1,1);
 
     const auto dev_id_0 = Kokkos::Tools::Experimental::device_id(execs.at(0));
     const auto dev_id_1 = Kokkos::Tools::Experimental::device_id(execs.at(1));
 
-    EventOnExecMatcher<EventNameMatcher, execution_space> matcher {.matcher = EventNameMatcher("runs-on-device"), .exec = execs.at(0)};
+    EventQueueMatcher<EventNameMatcher, execution_space> matcher {.matcher = EventNameMatcher("runs-on-device"), .exec = execs.at(0)};
 
     ASSERT_EQ   (matcher(BeginParallelForEvent{.name = "runs-on-device", .dev_id = dev_id_1}), dev_id_0 == dev_id_1);
     ASSERT_FALSE(matcher(BeginParallelForEvent{.name = "does-not-match", .dev_id = dev_id_0}));


### PR DESCRIPTION
## Summary

This PR renames `EventOnExecMatcher` to `EventQueueMatcher`.

The rationale is to try to bring everything related to "something being on a particular device" to the word "queue".

## Related to

- extracted from #43 
