### PR TITLE
callbacks(matchers): remove `matcher` member from `EventQueueMatcher`

### DIFF
--- a/include/kokkos-utils/callbacks/EventBeginEndIdMatcher.hpp
+++ b/include/kokkos-utils/callbacks/EventBeginEndIdMatcher.hpp
@@ -28,17 +28,17 @@ struct EventBeginEndIdMatcher
         const bool matching = matcher(event);
 
         if(matching)
-            matcher_stop.event_id = event.event_id;
+            matcher_end.event_id = event.event_id;
 
         return matching;
     }
 
     bool operator()(const end_event_t& event) const {
-        return matcher_stop(event);
+        return matcher_end(event);
     }
 
     BeginMatcherType matcher;
-    EventIdMatcher   matcher_stop {};
+    EventIdMatcher   matcher_end {};
 };
 
 } // namespace Kokkos::utils::callbacks

--- a/include/kokkos-utils/callbacks/EventQueueMatcher.hpp
+++ b/include/kokkos-utils/callbacks/EventQueueMatcher.hpp
@@ -8,19 +8,14 @@ namespace Kokkos::utils::callbacks
 {
 
 //! Match an event whose @c dev_id is the same as the one of @ref exec.
-template <Matcher MatcherType, Kokkos::utils::concepts::ExecutionSpace Exec>
+template <Kokkos::utils::concepts::ExecutionSpace Exec>
 struct EventQueueMatcher
 {
     template <EnqueuedEvent EventType>
-    bool operator()(const EventType& event)
-    {
-        if(event.dev_id == dev_id)
-            return matcher(event);
-        else
-            return false;
+    bool operator()(const EventType& event) const {
+        return event.dev_id == dev_id;
     }
 
-    MatcherType matcher;
     Exec exec;
     uint32_t dev_id = Kokkos::Tools::Experimental::device_id(exec);
 };

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -237,7 +237,7 @@ TEST(EventBeginEndIdMatcher, operator_parentheses)
 //! @test Check traits of @ref Kokkos::utils::callbacks::EventQueueMatcher.
 TEST(EventQueueMatcher, traits)
 {
-    using matcher_t = EventQueueMatcher<EventRegexMatcher, execution_space>;
+    using matcher_t = EventQueueMatcher<execution_space>;
 
     using enqueued_event_type_list_t = Kokkos::Impl::type_list<
         BeginParallelForEvent,
@@ -259,11 +259,10 @@ TEST(EventQueueMatcher, operator_parentheses)
     const auto dev_id_0 = Kokkos::Tools::Experimental::device_id(execs.at(0));
     const auto dev_id_1 = Kokkos::Tools::Experimental::device_id(execs.at(1));
 
-    EventQueueMatcher<EventNameMatcher, execution_space> matcher {.matcher = EventNameMatcher("runs-on-device"), .exec = execs.at(0)};
+    EventQueueMatcher<execution_space> matcher {.exec = execs.at(0)};
 
-    ASSERT_EQ   (matcher(BeginParallelForEvent{.name = "runs-on-device", .dev_id = dev_id_1}), dev_id_0 == dev_id_1);
-    ASSERT_FALSE(matcher(BeginParallelForEvent{.name = "does-not-match", .dev_id = dev_id_0}));
-    ASSERT_TRUE (matcher(BeginParallelForEvent{.name = "runs-on-device", .dev_id = dev_id_0}));
+    ASSERT_EQ  (matcher(BeginParallelForEvent{.name = "", .dev_id = dev_id_1}), dev_id_0 == dev_id_1);
+    ASSERT_TRUE(matcher(BeginParallelForEvent{.name = "", .dev_id = dev_id_0}));
 }
 
 //! @test Check traits of @ref Kokkos::utils::callbacks::EventIdMatcher.


### PR DESCRIPTION
## Summary

This PR removes the inner matcher. We rather envision to use some `And<MatcherType1, MatcherType2>` instead.

## Related to

- extracted from #43 
