### PR TITLE
feat(`timer listener`): add version with latency

### DIFF
--- a/include/kokkos-utils/callbacks/BeginEndTimerListener.hpp
+++ b/include/kokkos-utils/callbacks/BeginEndTimerListener.hpp
@@ -3,6 +3,7 @@
 
 #include "kokkos-utils/callbacks/ConjunctionMatcher.hpp"
 #include "kokkos-utils/callbacks/EnqueuedEventTimer.hpp"
+#include "kokkos-utils/callbacks/EnqueuedEventWithLaunchTimer.hpp"
 #include "kokkos-utils/callbacks/EventBeginEndIdMatcher.hpp"
 #include "kokkos-utils/callbacks/EventQueueMatcher.hpp"
 #include "kokkos-utils/callbacks/TimerListener.hpp"
@@ -18,12 +19,13 @@ namespace Kokkos::utils::callbacks
  * reduce, parallel scan, or deep copy operation. In such a situation, the execution space
  * instance passed to this class's constructor should be the same as the one passed to the workload.
  */
-template <Matcher MatcherType, Event BeginEventType, Kokkos::utils::concepts::ExecutionSpace Exec> requires MatcherFor<MatcherType, BeginEventType>
-struct BeginEndTimerListener : public TimerListener<EventBeginEndIdMatcher<BeginEventType, ConjunctionMatcher<EventQueueMatcher<Exec>, MatcherType>>, EnqueuedEventTimer<Exec>>
+template <Matcher MatcherType, Event BeginEventType, Kokkos::utils::concepts::ExecutionSpace Exec, typename TimerType = EnqueuedEventTimer<Exec>>
+requires MatcherFor<MatcherType, BeginEventType>
+struct BeginEndTimerListener : public TimerListener<EventBeginEndIdMatcher<BeginEventType, ConjunctionMatcher<EventQueueMatcher<Exec>, MatcherType>>, TimerType>
 {
     using queue_matcher_t = EventQueueMatcher<Exec>;
     using matcher_t       = EventBeginEndIdMatcher<BeginEventType, ConjunctionMatcher<queue_matcher_t, MatcherType>>;
-    using timer_t         = EnqueuedEventTimer<Exec>;
+    using timer_t         = TimerType;
     using base_t          = TimerListener<matcher_t, timer_t>;
 
     template <typename T>
@@ -33,21 +35,43 @@ struct BeginEndTimerListener : public TimerListener<EventBeginEndIdMatcher<Begin
     } {}
 };
 
-//! Timer listener for a parallel for that matches @p MatcherType.
+//! @name Template aliases using @ref EnqueuedEventTimer.
+///@{
+//! Timer listener for timing the execution of a parallel for that matches @p MatcherType.
 template <MatcherFor<BeginParallelForEvent> MatcherType, Kokkos::utils::concepts::ExecutionSpace Exec>
 using ParallelForTimerListener = BeginEndTimerListener<MatcherType, BeginParallelForEvent, Exec>;
 
-//! Timer listener for a parallel reduce that matches @p MatcherType.
+//! Timer listener for timing the execution of a parallel reduce that matches @p MatcherType.
 template <MatcherFor<BeginParallelReduceEvent> MatcherType, Kokkos::utils::concepts::ExecutionSpace Exec>
 using ParallelReduceTimerListener = BeginEndTimerListener<MatcherType, BeginParallelReduceEvent, Exec>;
 
-//! Timer listener for a parallel scan that matches @p MatcherType.
+//! Timer listener for timing the execution of a parallel scan that matches @p MatcherType.
 template <MatcherFor<BeginParallelScanEvent> MatcherType, Kokkos::utils::concepts::ExecutionSpace Exec>
 using ParallelScanTimerListener = BeginEndTimerListener<MatcherType, BeginParallelScanEvent, Exec>;
 
-//! Timer listener for a deep copy that matches @p MatcherType.
+//! Timer listener for timing the execution of a deep copy that matches @p MatcherType.
 template <MatcherFor<BeginDeepCopyEvent> MatcherType, Kokkos::utils::concepts::ExecutionSpace Exec>
 using DeepCopyTimerListener = BeginEndTimerListener<MatcherType, BeginDeepCopyEvent, Exec>;
+///@}
+
+//! @name Template aliases using @ref EnqueuedEventWithLaunchTimer.
+///@{
+//! Timer listener for timing the execution and the launch of a parallel for that matches @p MatcherType.
+template <MatcherFor<BeginParallelForEvent> MatcherType, Kokkos::utils::concepts::ExecutionSpace Exec>
+using ParallelForWithLaunchTimerListener = BeginEndTimerListener<MatcherType, BeginParallelForEvent, Exec, EnqueuedEventWithLaunchTimer<Exec>>;
+
+//! Timer listener for timing the execution and the launch of a parallel reduce that matches @p MatcherType.
+template <MatcherFor<BeginParallelReduceEvent> MatcherType, Kokkos::utils::concepts::ExecutionSpace Exec>
+using ParallelWithLaunchReduceTimerListener = BeginEndTimerListener<MatcherType, BeginParallelReduceEvent, Exec, EnqueuedEventWithLaunchTimer<Exec>>;
+
+//! Timer listener for timing the execution and the launch of a parallel scan that matches @p MatcherType.
+template <MatcherFor<BeginParallelScanEvent> MatcherType, Kokkos::utils::concepts::ExecutionSpace Exec>
+using ParallelWithLaunchScanTimerListener = BeginEndTimerListener<MatcherType, BeginParallelScanEvent, Exec, EnqueuedEventWithLaunchTimer<Exec>>;
+
+//! Timer listener for timing the execution and the launch of a deep copy that matches @p MatcherType.
+template <MatcherFor<BeginDeepCopyEvent> MatcherType, Kokkos::utils::concepts::ExecutionSpace Exec>
+using DeepCopyWithLaunchTimerListener = BeginEndTimerListener<MatcherType, BeginDeepCopyEvent, Exec, EnqueuedEventWithLaunchTimer<Exec>>;
+///@}
 
 } // namespace Kokkos::utils::callbacks
 

--- a/tests/callbacks/test_TimerListener.cpp
+++ b/tests/callbacks/test_TimerListener.cpp
@@ -144,6 +144,34 @@ TEST_F(TimerListenerTest, parallel_for)
     Manager::unregister_listener(par_for_timer_no_match.get());
 }
 
+//! @test Check the parallel for timer listener when used with @ref EnqueuedEventWithLaunchTimer.
+TEST_F(TimerListenerTest, with_launch)
+{
+    using parallel_for_with_launch_timer_t = ParallelForWithLaunchTimerListener<EventNameMatcher, execution_space>;
+
+    using unit_t = Kokkos::utils::timer::microseconds;
+    
+    Kokkos::utils::timer::Timer<void> timer_external;
+
+    const auto par_for_timer = std::make_shared<parallel_for_with_launch_timer_t>(
+        "computation - level 0 - pfor", exec
+    );
+
+    Manager::register_listener(par_for_timer);
+
+    timer_external.start();
+
+    MyWorkload<execution_space>{}.execute(exec);
+
+    timer_external.stop();
+
+    ASSERT_GT(par_for_timer->timer.duration(), unit_t{0.});
+    ASSERT_GT(par_for_timer->timer.launch(),   unit_t{0.});
+    ASSERT_LE(par_for_timer->timer.launch(), timer_external.duration());
+
+    Manager::unregister_listener(par_for_timer.get());
+}
+
 //! Listener to time regions whose name matches a regex.
 using region_timer_t = RegionTimerListener<EventRegexMatcher>;
 


### PR DESCRIPTION
This PR adds a version of timer listener that, in addition to the execution time, measures latency. 
