### PR TITLE
feat(callbacks): Add `EnqueuedEventTimer`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ target_sources(
             include/kokkos-utils/atomics/InsertOp.hpp
 
             include/kokkos-utils/callbacks/ConjunctionMatcher.hpp
+            include/kokkos-utils/callbacks/EnqueuedEventTimer.hpp
             include/kokkos-utils/callbacks/EventBeginEndIdMatcher.hpp
             include/kokkos-utils/callbacks/EventIdMatcher.hpp
             include/kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -39,8 +39,8 @@ get_target_property(KokkosUtils_TARGET_FILES_FOR_DOC kokkosutils HEADER_SET_${Ko
 get_property(KokkosUtils_FILES_FOR_DOC GLOBAL PROPERTY KokkosUtils_FILES_FOR_DOC)
 
 include(${CMAKE_SOURCE_DIR}/cmake/functions/list.cmake)
-check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 30)
-check_list_length(KokkosUtils_FILES_FOR_DOC        19)
+check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 31)
+check_list_length(KokkosUtils_FILES_FOR_DOC        20)
 
 #---- Add Doxygen as a target.
 #     See also https://cmake.org/cmake/help/latest/module/FindDoxygen.html.

--- a/include/kokkos-utils/callbacks/EnqueuedEventTimer.hpp
+++ b/include/kokkos-utils/callbacks/EnqueuedEventTimer.hpp
@@ -1,0 +1,42 @@
+#ifndef KOKKOS_UTILS_CALLBACKS_ENQUEUEDEVENTTIMER_HPP
+#define KOKKOS_UTILS_CALLBACKS_ENQUEUEDEVENTTIMER_HPP
+
+#include "kokkos-utils/callbacks/Events.hpp"
+#include "kokkos-utils/concepts/ExecutionSpace.hpp"
+#include "kokkos-utils/timer/Duration.hpp"
+#include "kokkos-utils/timer/Timer.hpp"
+
+namespace Kokkos::utils::callbacks
+{
+
+//! Timer for events that are enqueued on @ref exec.
+template <Kokkos::utils::concepts::ExecutionSpace Exec>
+struct EnqueuedEventTimer
+{
+    //! Start the timer. The event must be on @ref exec.
+    template <EnqueuedEvent EventType>
+    void start(const EventType& event)
+    {
+        if(event.dev_id != dev_id)
+            Kokkos::abort("EnqueuedEventTimer cannot be started for a wrongly enqueued event.");
+
+        timer.start(exec);
+    }
+
+    //! Stop the timer.
+    template <Event EventType>
+    void stop(const EventType&) {
+        timer.stop(exec);
+    }
+
+    template <typename Duration = Kokkos::utils::timer::milliseconds>
+    Duration duration() { return timer.template duration<Duration>(); }
+
+    Exec exec;
+    uint32_t dev_id = Kokkos::Tools::Experimental::device_id(exec);
+    Kokkos::utils::timer::Timer<Exec> timer {};
+};
+
+} // namespace Kokkos::utils::callbacks
+
+#endif // KOKKOS_UTILS_CALLBACKS_ENQUEUEDEVENTTIMER_HPP

--- a/tests/callbacks/CMakeLists.txt
+++ b/tests/callbacks/CMakeLists.txt
@@ -1,6 +1,7 @@
 set_property(GLOBAL APPEND PROPERTY KokkosUtils_FILES_FOR_DOC ${CMAKE_CURRENT_SOURCE_DIR}/Helpers.hpp)
 set_property(GLOBAL APPEND PROPERTY KokkosUtils_FILES_FOR_DOC ${CMAKE_CURRENT_SOURCE_DIR}/TestWorkload.hpp)
 
+add_one_test(NAME EnqueuedEventTimer)
 add_one_test(NAME Events)
 add_one_test(NAME Helpers)
 add_one_test(NAME Manager)

--- a/tests/callbacks/test_EnqueuedEventTimer.cpp
+++ b/tests/callbacks/test_EnqueuedEventTimer.cpp
@@ -1,0 +1,70 @@
+#include "gtest/gtest.h"
+
+#include "Kokkos_Core.hpp"
+
+#include "kokkos-utils/callbacks/EnqueuedEventTimer.hpp"
+#include "kokkos-utils/timer/Duration.hpp"
+
+/**
+ * @addtogroup unittests
+ *
+ * Enqueued event timer
+ * --------------------
+ *
+ * This group of tests check the behavior of @c Kokkos::utils::callbacks::EnqueuedEventTimer
+ * and related utilities.
+ */
+
+using execution_space = Kokkos::DefaultExecutionSpace;
+
+namespace Kokkos::utils::tests::callbacks
+{
+
+using namespace Kokkos::utils::callbacks;
+
+struct EnqueuedEventTimerTest : public ::testing::Test
+{
+public:
+    using timer_t = EnqueuedEventTimer<execution_space>;
+
+public:
+    void SetUp() override {
+        this->exec = Kokkos::Experimental::partition_space(execution_space{}, 1)[0];
+        this->dev_id = Kokkos::Tools::Experimental::device_id(this->exec);
+        this->timer = timer_t{this->exec};
+    }
+
+protected:
+    execution_space exec {};
+    uint32_t dev_id = 0;
+    timer_t timer {};
+};
+
+//! @test Check @ref Kokkos::utils::callbacks::EnqueuedEventTimer.
+TEST_F(EnqueuedEventTimerTest, duration)
+{
+    this->timer.start(BeginParallelForEvent{.name = "my-name", .dev_id = this->dev_id, .event_id = 1});
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    this->timer.stop(EndParallelForEvent{.event_id = 1});
+
+    const double elapsed = timer.template duration<Kokkos::utils::timer::milliseconds>().count();
+
+    //! Check that the elapsed time is greater than the waiting time of 100 ms.
+    ASSERT_GE(elapsed, 100.);
+}
+
+/**
+ * @test Check that @ref Kokkos::utils::callbacks::EnqueuedEventTimer::start aborts when called
+ *       on a wrongly enqueued event.
+ */
+TEST_F(EnqueuedEventTimerTest, start_aborts_for_wrongly_enqueued_event)
+{
+    ASSERT_DEATH({
+        this->timer.start(BeginParallelForEvent{.name = "my-name", .dev_id =
+            this->dev_id + 1, .event_id = 1});
+    }, "EnqueuedEventTimer cannot be started for a wrongly enqueued event.");
+}
+
+} // namespace Kokkos::utils::tests::callbacks


### PR DESCRIPTION
This PR adds `EnqueuedEventTimer`.

## Related to

- extracted from #43 
- to be followed up with extracting `EnqueuedEventWithLaunchTimer` from #81 
