### PR TITLE
feat(callbacks): Add `EnqueuedEventWithLaunchTimer`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ target_sources(
 
             include/kokkos-utils/callbacks/ConjunctionMatcher.hpp
             include/kokkos-utils/callbacks/EnqueuedEventTimer.hpp
+            include/kokkos-utils/callbacks/EnqueuedEventWithLaunchTimer.hpp
             include/kokkos-utils/callbacks/EventBeginEndIdMatcher.hpp
             include/kokkos-utils/callbacks/EventIdMatcher.hpp
             include/kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -39,7 +39,7 @@ get_target_property(KokkosUtils_TARGET_FILES_FOR_DOC kokkosutils HEADER_SET_${Ko
 get_property(KokkosUtils_FILES_FOR_DOC GLOBAL PROPERTY KokkosUtils_FILES_FOR_DOC)
 
 include(${CMAKE_SOURCE_DIR}/cmake/functions/list.cmake)
-check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 31)
+check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 32)
 check_list_length(KokkosUtils_FILES_FOR_DOC        20)
 
 #---- Add Doxygen as a target.

--- a/include/kokkos-utils/callbacks/EnqueuedEventWithLaunchTimer.hpp
+++ b/include/kokkos-utils/callbacks/EnqueuedEventWithLaunchTimer.hpp
@@ -1,0 +1,49 @@
+#ifndef KOKKOS_UTILS_CALLBACKS_ENQUEUEDEVENTWITHLAUNCHTIMER_HPP
+#define KOKKOS_UTILS_CALLBACKS_ENQUEUEDEVENTWITHLAUNCHTIMER_HPP
+
+#include "kokkos-utils/callbacks/Events.hpp"
+#include "kokkos-utils/concepts/ExecutionSpace.hpp"
+#include "kokkos-utils/timer/Duration.hpp"
+#include "kokkos-utils/timer/Timer.hpp"
+
+namespace Kokkos::utils::callbacks
+{
+
+//! Timer for events that are enqueued on @ref exec. This timer also measures the launch time.
+template <Kokkos::utils::concepts::ExecutionSpace Exec>
+struct EnqueuedEventWithLaunchTimer
+{
+    //! Start the timer. The event must be on @ref exec.
+    template <EnqueuedEvent EventType>
+    void start(const EventType& event)
+    {
+        if(event.dev_id != dev_id)
+            Kokkos::abort("EnqueuedEventTimer cannot be started for a wrongly enqueued event.");
+
+        timer.start(exec);
+        timer_launch.start();
+    }
+
+    //! Stop the timer.
+    template <Event EventType>
+    void stop(const EventType&)
+    {
+        timer_launch.stop();
+        timer.stop(exec);
+    }
+
+    template <typename Duration = Kokkos::utils::timer::milliseconds>
+    Duration duration() { return timer.template duration<Duration>(); }
+
+    template <typename Duration = Kokkos::utils::timer::milliseconds>
+    Duration launch() { return timer_launch.template duration<Duration>(); }
+
+    Exec exec;
+    uint32_t dev_id = Kokkos::Tools::Experimental::device_id(exec);
+    Kokkos::utils::timer::Timer<Exec> timer {};
+    Kokkos::utils::timer::Timer<void> timer_launch {};
+};
+
+} // namespace Kokkos::utils::callbacks
+
+#endif // KOKKOS_UTILS_CALLBACKS_ENQUEUEDEVENTWITHLAUNCHTIMER_HPP

--- a/tests/callbacks/test_EnqueuedEventTimer.cpp
+++ b/tests/callbacks/test_EnqueuedEventTimer.cpp
@@ -3,6 +3,7 @@
 #include "Kokkos_Core.hpp"
 
 #include "kokkos-utils/callbacks/EnqueuedEventTimer.hpp"
+#include "kokkos-utils/callbacks/EnqueuedEventWithLaunchTimer.hpp"
 #include "kokkos-utils/timer/Duration.hpp"
 
 /**
@@ -22,44 +23,93 @@ namespace Kokkos::utils::tests::callbacks
 
 using namespace Kokkos::utils::callbacks;
 
-struct EnqueuedEventTimerTest : public ::testing::Test
+template <typename TimerType>
+struct TimerTest : public ::testing::Test
 {
-public:
-    using timer_t = EnqueuedEventTimer<execution_space>;
-
 public:
     void SetUp() override {
         this->exec = Kokkos::Experimental::partition_space(execution_space{}, 1)[0];
         this->dev_id = Kokkos::Tools::Experimental::device_id(this->exec);
-        this->timer = timer_t{this->exec};
+        this->timer = TimerType{this->exec};
     }
 
 protected:
     execution_space exec {};
     uint32_t dev_id = 0;
-    timer_t timer {};
+    TimerType timer {};
 };
 
-//! @test Check @ref Kokkos::utils::callbacks::EnqueuedEventTimer.
+struct EnqueuedEventTimerTest : public TimerTest<EnqueuedEventTimer<execution_space>> {};
+
+//! @test Check the duration reported by @ref Kokkos::utils::callbacks::EnqueuedEventTimer.
 TEST_F(EnqueuedEventTimerTest, duration)
 {
     this->timer.start(BeginParallelForEvent{.name = "my-name", .dev_id = this->dev_id, .event_id = 1});
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    this->timer.stop(EndParallelForEvent{.event_id = 1});
+
+    const auto duration = this->timer.template duration<Kokkos::utils::timer::milliseconds>();
+
+    //! Check that the duration is greater than 0.
+    ASSERT_GE(duration.count(), 0.);
+}
+
+struct EnqueuedEventWithLaunchTimerTest : public TimerTest<EnqueuedEventWithLaunchTimer<execution_space>> {};
+
+//! @test Check the enqueued event and launch durations reported by @ref Kokkos::utils::callbacks::EnqueuedEventWithLaunchTimer.
+TEST_F(EnqueuedEventWithLaunchTimerTest, duration)
+{
+    using unit_t = Kokkos::utils::timer::microseconds;
+
+    constexpr unit_t sleep_for_h{5.};
+
+    Kokkos::utils::timer::Timer<void>            timer_outer_h {};
+    Kokkos::utils::timer::Timer<execution_space> timer_inner_d {};
+
+    timer_outer_h.start();
+
+    this->timer.start(BeginParallelForEvent{.name = "my-name", .dev_id = this->dev_id, .event_id = 1});
+
+    std::this_thread::sleep_for(sleep_for_h);
+
+    timer_inner_d.start(this->exec);
+
+    timer_inner_d.stop(this->exec);
 
     this->timer.stop(EndParallelForEvent{.event_id = 1});
 
-    const double elapsed = timer.template duration<Kokkos::utils::timer::milliseconds>().count();
+    const auto duration = this->timer.template duration<unit_t>();
 
-    //! Check that the elapsed time is greater than the waiting time of 100 ms.
-    ASSERT_GE(elapsed, 100.);
+    timer_outer_h.stop();
+
+    const auto launch_duration = this->timer.template launch<unit_t>();
+
+    const auto outer_duration = timer_outer_h.template duration<unit_t>();
+    const auto inner_duration = timer_inner_d.template duration<unit_t>();
+
+    //! Check that the duration is greater than 0. and smaller than the duration of the outer timer.
+    ASSERT_GE(duration, unit_t{0.});
+    ASSERT_GE(duration, inner_duration);
+    ASSERT_LE(duration, outer_duration);
+
+    //! Check that the launch duration is greater than 0. and smaller than the duration of the outer timer.
+    ASSERT_GE(launch_duration, sleep_for_h);
+    ASSERT_LE(launch_duration, outer_duration);
 }
 
+using TimerTypes = ::testing::Types<
+    EnqueuedEventTimer<execution_space>,
+    EnqueuedEventWithLaunchTimer<execution_space>
+>;
+
+TYPED_TEST_SUITE(TimerTest, TimerTypes);
+
 /**
- * @test Check that @ref Kokkos::utils::callbacks::EnqueuedEventTimer::start aborts when called
+ * @test Check that the @c start method of @ref Kokkos::utils::callbacks::EnqueuedEventTimer
+ *       and @ref Kokkos::utils::callbacks::EnqueuedEventWithLaunchTimer aborts when called
  *       on a wrongly enqueued event.
  */
-TEST_F(EnqueuedEventTimerTest, start_aborts_for_wrongly_enqueued_event)
+TYPED_TEST(TimerTest, start_aborts_for_wrongly_enqueued_event)
 {
     ASSERT_DEATH({
         this->timer.start(BeginParallelForEvent{.name = "my-name", .dev_id =


### PR DESCRIPTION
This PR adds the enqueued event timer that also measures the launch time.

## Related to

- extracted from #81 
- follow up for #82 
