### PR TITLE
tests(fixture): introduce an execution space instance test fixture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ target_sources(
             include/kokkos-utils/impl/type_list.hpp
             include/kokkos-utils/impl/type_traits.hpp
 
+            include/kokkos-utils/tests/fixtures/ExecutionSpaceInstanceFixture.hpp
+
             include/kokkos-utils/timer/Duration.hpp
             include/kokkos-utils/timer/Event.hpp
             include/kokkos-utils/timer/Timer.hpp

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -39,7 +39,7 @@ get_target_property(KokkosUtils_TARGET_FILES_FOR_DOC kokkosutils HEADER_SET_${Ko
 get_property(KokkosUtils_FILES_FOR_DOC GLOBAL PROPERTY KokkosUtils_FILES_FOR_DOC)
 
 include(${CMAKE_SOURCE_DIR}/cmake/functions/list.cmake)
-check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 32)
+check_list_length(KokkosUtils_TARGET_FILES_FOR_DOC 33)
 check_list_length(KokkosUtils_FILES_FOR_DOC        20)
 
 #---- Add Doxygen as a target.

--- a/include/kokkos-utils/tests/fixtures/ExecutionSpaceInstanceFixture.hpp
+++ b/include/kokkos-utils/tests/fixtures/ExecutionSpaceInstanceFixture.hpp
@@ -1,0 +1,22 @@
+#ifndef KOKKOS_UTILS_TESTS_HELPERS_HPP
+#define KOKKOS_UTILS_TESTS_HELPERS_HPP
+
+#include "kokkos-utils/concepts/ExecutionSpace.hpp"
+
+namespace Kokkos::utils::tests
+{
+
+//! Fixture class that creates a new execution space instance.
+template <Kokkos::utils::concepts::ExecutionSpace Exec>
+class ExecutionSpaceInstanceFixture
+{
+public:
+    ExecutionSpaceInstanceFixture() : exec(Kokkos::Experimental::partition_space(Exec{}, 1)[0]) {}
+
+protected:
+    Exec exec;
+};
+
+} // namespace Kokkos::utils::tests
+
+#endif // KOKKOS_UTILS_TESTS_HELPERS_HPP

--- a/tests/callbacks/test_Manager.cpp
+++ b/tests/callbacks/test_Manager.cpp
@@ -5,6 +5,7 @@
 
 #include "kokkos-utils/callbacks/Helpers.hpp"
 #include "kokkos-utils/impl/type_traits.hpp"
+#include "kokkos-utils/tests/fixtures/ExecutionSpaceInstanceFixture.hpp"
 
 #include "tests/callbacks/TestWorkload.hpp"
 
@@ -24,16 +25,9 @@ namespace Kokkos::utils::tests::callbacks
 
 using namespace Kokkos::utils::callbacks;
 
-class ManagerTest : public ManagerTestFixture
-{
-public:
-    void SetUp() override {
-        this->exec = Kokkos::Experimental::partition_space(execution_space{}, 1)[0];
-    }
-
-protected:
-    execution_space exec {};
-};
+class ManagerTest : public ManagerTestFixture,
+                    public ExecutionSpaceInstanceFixture<execution_space>
+{};
 
 //! @test Check properties of @ref Kokkos::utils::callbacks::Manager being a singleton class.
 TEST(Manager, singleton_traits)

--- a/tests/callbacks/test_RecorderListener.cpp
+++ b/tests/callbacks/test_RecorderListener.cpp
@@ -3,12 +3,12 @@
 
 #include "Kokkos_Core.hpp"
 
-#include "kokkos-utils/impl/type_traits.hpp"
-
 #include "kokkos-utils/callbacks/EventInProfileSectionMatcher.hpp"
 #include "kokkos-utils/callbacks/EventRegexMatcher.hpp"
 #include "kokkos-utils/callbacks/Helpers.hpp"
 #include "kokkos-utils/callbacks/RecorderListener.hpp"
+#include "kokkos-utils/impl/type_traits.hpp"
+#include "kokkos-utils/tests/fixtures/ExecutionSpaceInstanceFixture.hpp"
 
 #include "tests/callbacks/Helpers.hpp"
 #include "tests/callbacks/TestWorkload.hpp"
@@ -32,16 +32,9 @@ using namespace Kokkos::utils::callbacks;
 //! Listener to record events that occur in a profile section.
 using event_in_profile_section_recorder_t = RecorderListener<EventInProfileSectionMatcher<EventRegexMatcher>, EventTypeList>;
 
-class RecorderListenerTest : public ManagerTestFixture
-{
-public:
-    void SetUp() override {
-        this->exec = Kokkos::Experimental::partition_space(execution_space{}, 1)[0];
-    }
-
-protected:
-    execution_space exec {};
-};
+class RecorderListenerTest : public ManagerTestFixture,
+                             public ExecutionSpaceInstanceFixture<execution_space>
+{};
 
 //! @test Check traits of @ref Kokkos::utils::callbacks::RecorderListener.
 TEST(RecorderListener, traits)

--- a/tests/timer/test_Event.cpp
+++ b/tests/timer/test_Event.cpp
@@ -2,6 +2,7 @@
 
 #include "Kokkos_Core.hpp"
 
+#include "kokkos-utils/tests/fixtures/ExecutionSpaceInstanceFixture.hpp"
 #include "kokkos-utils/timer/Duration.hpp"
 #include "kokkos-utils/timer/Event.hpp"
 
@@ -24,16 +25,9 @@ namespace Kokkos::utils::tests::timer
 using namespace Kokkos::utils::timer;
 
 template <typename T>
-struct EventTest : public ::testing::Test
-{
-public:
-    void SetUp() override {
-        this->exec = Kokkos::Experimental::partition_space(execution_space{}, 1)[0];
-    }
-
-protected:
-    execution_space exec {};
-};
+struct EventTest : public ::testing::Test,
+                   public ExecutionSpaceInstanceFixture<execution_space>
+{};
 
 using EventTypes = ::testing::Types<
     Event<void>,

--- a/tests/timer/test_Timer.cpp
+++ b/tests/timer/test_Timer.cpp
@@ -2,6 +2,7 @@
 
 #include "Kokkos_Core.hpp"
 
+#include "kokkos-utils/tests/fixtures/ExecutionSpaceInstanceFixture.hpp"
 #include "kokkos-utils/timer/Timer.hpp"
 
 /**
@@ -23,16 +24,9 @@ namespace Kokkos::utils::tests::timer
 using namespace Kokkos::utils::timer;
 
 template <typename T>
-struct TimerTest : public ::testing::Test
-{
-public:
-    void SetUp() override {
-        this->exec = Kokkos::Experimental::partition_space(execution_space{}, 1)[0];
-    }
-
-protected:
-    execution_space exec {};
-};
+struct TimerTest : public ::testing::Test,
+                   public ExecutionSpaceInstanceFixture<execution_space>
+{};
 
 using TimerTypes = ::testing::Types<
     Timer<void>,


### PR DESCRIPTION
### Summary

This fixture is useful to ensure that a test runs with a new (possibly unique) execution space instance.

I've explicitly added it to the `include` directory because we clearly want to ship it.

### Related

- will be useful in #43 