### PR TITLE
callbacks(helpers): partial matchers

### DIFF
--- a/include/kokkos-utils/callbacks/Events.hpp
+++ b/include/kokkos-utils/callbacks/Events.hpp
@@ -303,10 +303,14 @@ using paired_event_t = typename PairedEventType<EventType>::type;
 
 //! @name Stream operators.
 ///@{
-//! Helper function related to the implementation of the stream operators.
-template <Event EventType>
+/**
+ * @brief Helper function to remove the @c Kokkos::utils::callbacks:: prefix.
+ *
+ * @note For the sake of performance, the size is hardcoded to @c 26 instead of doing a search.
+ */
+template <typename T>
 constexpr auto get_name() {
-    return Kokkos::Impl::TypeInfo<EventType>::name().substr(26); // erase "Kokkos::utils::callbacks::"
+    return Kokkos::Impl::TypeInfo<T>::name().substr(26);
 }
 
 template <Event EventType>
@@ -361,6 +365,11 @@ inline std::ostream& operator<<(std::ostream &out, const PushRegionEvent& event)
 inline std::ostream& operator<<(std::ostream &out, const ProfileEvent& event) {
     return out << get_name<ProfileEvent>() << ": "
                << "{name = " << std::quoted(event.name) << "}";
+}
+
+inline std::ostream& operator<<(std::ostream& out, const AllocDescriptor& descr) {
+    return out << get_name<AllocDescriptor>() << ": "
+               << "{name = " << std::quoted(descr.name) << " (" << descr.kpsh.name << ", " << descr.ptr << ") of size " << descr.size << '}';
 }
 ///@}
 

--- a/include/kokkos-utils/callbacks/Helpers.hpp
+++ b/include/kokkos-utils/callbacks/Helpers.hpp
@@ -34,6 +34,8 @@ DEFINE_EVENT_MATCHER(BeginFenceEvent)
 DEFINE_EVENT_MATCHER(EndFenceEvent)
 DEFINE_EVENT_MATCHER(AllocateDataEvent)
 DEFINE_EVENT_MATCHER(DeallocateDataEvent)
+DEFINE_EVENT_MATCHER(BeginDeepCopyEvent)
+DEFINE_EVENT_MATCHER(EndDeepCopyEvent)
 DEFINE_EVENT_MATCHER(CreateProfileSectionEvent)
 DEFINE_EVENT_MATCHER(DestroyProfileSectionEvent)
 DEFINE_EVENT_MATCHER(StartProfileSectionEvent)
@@ -136,6 +138,51 @@ template <typename T, typename... Matchers>
 auto ContainsInOrder(Matchers&&... matchers) {
     return ::testing::MakePolymorphicMatcher(impl::ContainsInOrderMatcher<T, std::remove_cvref_t<Matchers>...>(std::forward<Matchers>(matchers)...));
 }
+
+template <typename T>
+struct PartialMatcher;
+
+/**
+ * @brief For an allocation, one typically wants to check the memory space, label and size of the allocation.
+ *
+ * Therefore, the @ref Kokkos::utils::callbacks::AllocDescriptor::ptr is not included in the comparison (as it is subject to change from one run to another).
+ */
+template <>
+struct PartialMatcher<AllocDescriptor>
+{
+    decltype(auto) operator()(AllocDescriptor descr) const {
+        return ::testing::AllOf(
+            ::testing::Field(
+                &AllocDescriptor::kpsh,
+                ::testing::Field(&Kokkos_Profiling_SpaceHandle::name, ::testing::StrEq(descr.kpsh.name))
+            ),
+            ::testing::Field(
+                &AllocDescriptor::name,
+                ::testing::StrEq(std::move(descr.name))
+            ),
+            ::testing::Field(
+                &AllocDescriptor::size,
+                ::testing::Eq(descr.size)
+            )
+        );
+    }
+};
+
+/**
+ * Uses @ref Kokkos::utils::callbacks::PartialMatcher<AllocDescriptor> for the
+ * @ref Kokkos::utils::callbacks::BeginDeepCopyEvent::dst and 
+ * @ref Kokkos::utils::callbacks::BeginDeepCopyEvent::src.
+ */
+template <>
+struct PartialMatcher<BeginDeepCopyEvent>
+{
+    decltype(auto) operator()(BeginDeepCopyEvent event) const {
+        return ::testing::AllOf(
+            ::testing::Field(&BeginDeepCopyEvent::dst, PartialMatcher<AllocDescriptor>{}(std::move(event.dst))),
+            ::testing::Field(&BeginDeepCopyEvent::src, PartialMatcher<AllocDescriptor>{}(std::move(event.src)))
+        );
+    }
+};
 
 } // namespace Kokkos::utils::callbacks
 

--- a/tests/callbacks/test_Helpers.cpp
+++ b/tests/callbacks/test_Helpers.cpp
@@ -47,4 +47,48 @@ TEST(ContainsInOrderMatcher, Matches)
     ASSERT_THAT(vec, ::testing::Not(ContainsInOrder<int>(::testing::Eq(2), ::testing::Eq(1))));
 }
 
+//! @test Check that @ref Kokkos::utils::callbacks::PartialMatcher works as expected for @ref Kokkos::utils::callbacks::AllocDescriptor.
+TEST(PartialMatcher, AllocDescriptor)
+{
+    const AllocDescriptor event{.kpsh = {.name = "Cuda"}, .name = "my-label", .ptr = reinterpret_cast<void*>(0x7ffee2b9d8f0), .size = 128};
+
+    const AllocDescriptor partial_match              {.kpsh = {.name = "Cuda"}, .name = "my-label", .size = 128};
+    const AllocDescriptor partial_no_match_kpsh_name {.kpsh = {.name = "osef"}, .name = "my-label", .size = 128};
+    const AllocDescriptor partial_no_match_name      {.kpsh = {.name = "Cuda"}, .name = "my-xxxxx", .size = 128};
+    const AllocDescriptor partial_no_match_size      {.kpsh = {.name = "Cuda"}, .name = "my-label", .size = 129};
+
+    ASSERT_THAT(event,                PartialMatcher<AllocDescriptor>{}(partial_match));
+    ASSERT_THAT(event, ::testing::Not(PartialMatcher<AllocDescriptor>{}(partial_no_match_kpsh_name)));
+    ASSERT_THAT(event, ::testing::Not(PartialMatcher<AllocDescriptor>{}(partial_no_match_name)));
+    ASSERT_THAT(event, ::testing::Not(PartialMatcher<AllocDescriptor>{}(partial_no_match_size)));
+}
+
+//! @test Check that @ref Kokkos::utils::callbacks::PartialMatcher works as expected for @ref Kokkos::utils::callbacks::BeginDeepCopyEvent.
+TEST(PartialMatcher, BeginDeepCopyEvent)
+{
+    const BeginDeepCopyEvent event {
+        .dst = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-dst", .ptr = reinterpret_cast<void*>(0x7ffee2b9d8f0), .size = 128},
+        .src = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-src", .ptr = reinterpret_cast<void*>(0x7ffee2b9d8f0), .size = 128}
+    };
+
+    const BeginDeepCopyEvent partial_match {
+        .dst = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-dst", .size = 128},
+        .src = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-src", .size = 128}
+    };
+
+    const BeginDeepCopyEvent partial_no_match_dst {
+        .dst = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-xxx", .size = 128},
+        .src = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-src", .size = 128}
+    };
+
+    const BeginDeepCopyEvent partial_no_match_src {
+        .dst = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-dst", .size = 128},
+        .src = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-xxx", .size = 128}
+    };
+
+    ASSERT_THAT(event,                PartialMatcher<BeginDeepCopyEvent>{}(partial_match));
+    ASSERT_THAT(event, ::testing::Not(PartialMatcher<BeginDeepCopyEvent>{}(partial_no_match_dst)));
+    ASSERT_THAT(event, ::testing::Not(PartialMatcher<BeginDeepCopyEvent>{}(partial_no_match_src)));
+}
+
 } // namespace Kokkos::utils::tests::callbacks


### PR DESCRIPTION
## Summary

This PR adds missing `DEFINE_EVENT_MATCHER` for `BeginDeepCopyEvent` and `EndDeepCopyEvent`.

It also introduces *partial matchers* that are especially useful for comparing events *partially*.

For instance, for allocation-related events, we generally don't want to check the pointer address.
