### PR TITLE
Introduce a partial ordering for alloc descriptor.

### DIFF
--- a/include/kokkos-utils/callbacks/Events.hpp
+++ b/include/kokkos-utils/callbacks/Events.hpp
@@ -106,6 +106,15 @@ struct AllocDescriptor
     uint64_t size = 0;
 
     bool operator==(const AllocDescriptor&) const = default;
+
+    std::partial_ordering operator<=>(const AllocDescriptor& other) const
+    {
+        if (kpsh != other.kpsh) {
+            return std::partial_ordering::unordered;
+        } else {
+            return std::tie(name, size) <=> std::tie(other.name, other.size);
+        }
+    }
 };
 
 //! Allocate-data event associated with @c Kokkos::Tools::Experimental::EventSet::allocate_data.
@@ -131,6 +140,8 @@ struct BeginDeepCopyEvent
     AllocDescriptor src {};
 
     bool operator==(const BeginDeepCopyEvent&) const = default;
+
+    std::partial_ordering operator<=>(const BeginDeepCopyEvent& other) const = default;
 };
 
 //! End-deep-copy event associated with @c Kokkos::Tools::Experimental::EventSet::end_deep_copy.

--- a/include/kokkos-utils/callbacks/Helpers.hpp
+++ b/include/kokkos-utils/callbacks/Helpers.hpp
@@ -184,6 +184,9 @@ struct PartialMatcher<BeginDeepCopyEvent>
     }
 };
 
+//! Defines a matcher @c Equivalent() to match an argument that is equivalent to @c val in the sense of a partial or weak ordering.
+MATCHER_P(Equivalent, val, "") { const auto cmp = arg <=> val; return cmp == std::partial_ordering::equivalent; }
+
 } // namespace Kokkos::utils::callbacks
 
 #endif // KOKKOS_UTILS_CALLBACKS_HELPERS_HPP

--- a/tests/callbacks/test_Helpers.cpp
+++ b/tests/callbacks/test_Helpers.cpp
@@ -91,4 +91,48 @@ TEST(PartialMatcher, BeginDeepCopyEvent)
     ASSERT_THAT(event, ::testing::Not(PartialMatcher<BeginDeepCopyEvent>{}(partial_no_match_src)));
 }
 
+//! @test Check that @ref Kokkos::utils::callbacks::Equivalent works as expected for @ref Kokkos::utils::callbacks::AllocDescriptor.
+TEST(Equivalent, AllocDescriptor)
+{
+    const AllocDescriptor event{.kpsh = {.name = "Cuda"}, .name = "my-label", .ptr = reinterpret_cast<void*>(0x7ffee2b9d8f0), .size = 128};
+
+    const AllocDescriptor partial_match              {.kpsh = {.name = "Cuda"}, .name = "my-label", .size = 128};
+    const AllocDescriptor partial_no_match_kpsh_name {.kpsh = {.name = "osef"}, .name = "my-label", .size = 128};
+    const AllocDescriptor partial_no_match_name      {.kpsh = {.name = "Cuda"}, .name = "my-xxxxx", .size = 128};
+    const AllocDescriptor partial_no_match_size      {.kpsh = {.name = "Cuda"}, .name = "my-label", .size = 129};
+
+    ASSERT_THAT(event,                Equivalent(partial_match));
+    ASSERT_THAT(event, ::testing::Not(Equivalent(partial_no_match_kpsh_name)));
+    ASSERT_THAT(event, ::testing::Not(Equivalent(partial_no_match_name)));
+    ASSERT_THAT(event, ::testing::Not(Equivalent(partial_no_match_size)));
+}
+
+//! @test Check that @ref Kokkos::utils::callbacks::Equivalent works as expected for @ref Kokkos::utils::callbacks::BeginDeepCopyEvent.
+TEST(Equivalent, BeginDeepCopyEvent)
+{
+    const BeginDeepCopyEvent event {
+        .dst = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-dst", .ptr = reinterpret_cast<void*>(0x7ffee2b9d8f0), .size = 128},
+        .src = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-src", .ptr = reinterpret_cast<void*>(0x7ffee2b9d8f0), .size = 128}
+    };
+
+    const BeginDeepCopyEvent partial_match {
+        .dst = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-dst", .size = 128},
+        .src = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-src", .size = 128}
+    };
+
+    const BeginDeepCopyEvent partial_no_match_dst {
+        .dst = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-xxx", .size = 128},
+        .src = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-src", .size = 128}
+    };
+
+    const BeginDeepCopyEvent partial_no_match_src {
+        .dst = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-dst", .size = 128},
+        .src = AllocDescriptor{.kpsh = {.name = "Cuda"}, .name = "my-xxx", .size = 128}
+    };
+
+    ASSERT_THAT(event,                Equivalent(partial_match));
+    ASSERT_THAT(event, ::testing::Not(Equivalent(partial_no_match_dst)));
+    ASSERT_THAT(event, ::testing::Not(Equivalent(partial_no_match_src)));
+}
+
 } // namespace Kokkos::utils::tests::callbacks


### PR DESCRIPTION
This PR is a follow up for:
- #91  

The idea of this PR is to link the "partial" of the "partial matcher" to how C++ 20 allows us to define a weak or partial ordering for objects.

I.e., we overload the comparison operator of the `AllocDescriptor` with a custom comparison operator that does not take into account the pointer member. 

And then we define a new matcher that checks equivalence using the three-way comparison operator.

An advantage is that assertions become a bit shorter:

```
ASSERT_THAT(event, PartialMatcher<BeginDeepCopyEvent>{}(partial_match));
```

becomes

```
ASSERT_THAT(event, Equivalent(partial_match));
```

@romintomasetti, what do you think?


