### PR TITLE
docker(benchmark): update sha

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -118,7 +118,7 @@ RUN <<EOF
 
     cd googlebenchmark
 
-    git checkout 0bf52e0fe082a8d1d64a28f614359af36579cb15
+    git checkout 84b9b21a125b504864fa9876946207b3e8cb389d
 
     cmake -S . -B build \
         -DCMAKE_INSTALL_PREFIX=/opt/google-benchmark-${GOOGLEBENCHMARK_VERSION} \


### PR DESCRIPTION
## Summary

We're still using our fork, and I guess @maartenarnst recently force pushed on the branch.
