### PR TITLE
Cleaning: use `[[nodiscard]]` due to deprecation of `Kokkos` macro

### DIFF
--- a/include/kokkos-utils/tests/scoped/ExecutionSpace.hpp
+++ b/include/kokkos-utils/tests/scoped/ExecutionSpace.hpp
@@ -8,7 +8,7 @@ namespace Kokkos::utils::tests::scoped
 
 //! Create a new execution space instance with RAII semantics.
 template <Kokkos::utils::concepts::ExecutionSpace Exec>
-struct KOKKOS_ATTRIBUTE_NODISCARD ExecutionSpace
+struct [[nodiscard]] ExecutionSpace
 {
     ExecutionSpace() : exec(Kokkos::Experimental::partition_space(Exec{}, 1)[0]) {}
 

--- a/include/kokkos-utils/tests/scoped/callbacks/Manager.hpp
+++ b/include/kokkos-utils/tests/scoped/callbacks/Manager.hpp
@@ -6,7 +6,7 @@
 namespace Kokkos::utils::tests::scoped::callbacks
 {
 //! Initializing and finalizing @ref Kokkos::utils::callbacks::Manager in a RAII manner.
-struct KOKKOS_ATTRIBUTE_NODISCARD Manager
+struct [[nodiscard]] Manager
 {
     Manager()  { Kokkos::utils::callbacks::Manager::initialize(); }
     ~Manager() { Kokkos::utils::callbacks::Manager::finalize(); }


### PR DESCRIPTION
After:
- https://github.com/kokkos/kokkos/pull/8388
