### PR TITLE
Discard Kokkos tag file

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -7,16 +7,6 @@ find_package(
     REQUIRED
 )
 
-#---- Fetch Kokkos tag file. Note that the Kokkos project does not generate a tag file, but Trilinos does.
-set(KOKKOS_TAG_FILE     "${CMAKE_CURRENT_BINARY_DIR}/Kokkos.tag")
-set(KOKKOS_TAG_FILE_URL "https://docs.trilinos.org/dev/packages/common/tag_files/kokkos.tag")
-message(STATUS "Fetching Kokkos tag file with ${KOKKOS_TAG_FILE_URL} and storing it to ${KOKKOS_TAG_FILE}.")
-file(DOWNLOAD ${KOKKOS_TAG_FILE_URL} ${KOKKOS_TAG_FILE} STATUS fetch_kokkos_tag_file_status)
-list(GET fetch_kokkos_tag_file_status 0 fetch_kokkos_tag_file_status_return_code)
-if(NOT fetch_kokkos_tag_file_status_return_code EQUAL 0)
-    message(FATAL_ERROR "An error occurred while fetching tag file for package Kokkos with ${KOKKOS_TAG_FILE_URL} (${fetch_kokkos_tag_file_status}).")
-endif()
-
 #---- Our 'homepage' is the README file.
 set(HOMEPAGE_MD ${CMAKE_SOURCE_DIR}/README.md)
 
@@ -30,7 +20,6 @@ set(DOXYGEN_WARN_AS_ERROR YES)
 set(DOXYGEN_SOURCE_BROWSER YES)
 set(DOXYGEN_WARN_IF_UNDOCUMENTED NO)
 set(DOXYGEN_GENERATE_TAGFILE "${CMAKE_CURRENT_BINARY_DIR}/html/${CMAKE_PROJECT_NAME}.tag")
-set(DOXYGEN_TAGFILES "${KOKKOS_TAG_FILE}")
 set(DOXYGEN_MACRO_EXPANSION YES)
 
 #---- Extract files for documentation.

--- a/include/kokkos-utils/callbacks/Events.hpp
+++ b/include/kokkos-utils/callbacks/Events.hpp
@@ -18,8 +18,8 @@ bool operator==(const Kokkos_Profiling_SpaceHandle& fst, const Kokkos_Profiling_
 /**
  * @name Event types.
  *
- * Each event is an aggregate holding the argument values of a corresponding @ref Kokkos profiling function
- * associated with a @ref Kokkos profiling callback.
+ * Each event is an aggregate holding the argument values of a corresponding @c Kokkos profiling function
+ * associated with a @c Kokkos profiling callback.
  *
  * See also:
  *     - https://github.com/kokkos/kokkos/blob/4c4fa17dccbd01106c0fa8e03fd23fe70896dc1c/core/src/impl/Kokkos_Profiling_C_Interface.h#L47-L113
@@ -404,7 +404,7 @@ GET_CALLBACK_FROM_EVENTSET(PushRegionEvent,            push_region)
 GET_CALLBACK_FROM_EVENTSET(PopRegionEvent,             pop_region)
 GET_CALLBACK_FROM_EVENTSET(ProfileEvent,               profile_event)
 
-//! Get the setter function of a @ref Kokkos profiling callback corresponding to @p EventType.
+//! Get the setter function of a @c Kokkos profiling callback corresponding to @p EventType.
 template <Event EventType>
 auto get_callback_setter();
 

--- a/include/kokkos-utils/callbacks/Manager.hpp
+++ b/include/kokkos-utils/callbacks/Manager.hpp
@@ -101,10 +101,10 @@ using listener_call_opr_list_tuple_t = Kokkos::utils::impl::type_list_to_tuple_t
 } // namespace impl
 
 /**
- * @brief Class to manage @ref Kokkos profiling callback calls.
+ * @brief Class to manage @c Kokkos profiling callback calls.
  *
  * This class allows the registration of callable objects as listeners for events representing
- * @ref Kokkos profiling callback calls.
+ * @c Kokkos profiling callback calls.
  *
  * On initialization, this class uses @c Kokkos::Tools::Experimental::get_callbacks to retrieve
  * the callback function pointers already set within @ref Kokkos. Note that this class refers to
@@ -123,15 +123,15 @@ using listener_call_opr_list_tuple_t = Kokkos::utils::impl::type_list_to_tuple_t
  * refers to the call operators of these registered callable objects as the "registered callbacks".
  *
  * This class uses the setters @c Kokkos::Tools::Experimental::set_<event_type_name>_callback
- * to set the @ref Kokkos callback function pointers to this class's dispatching functions for the
- * event types for which there are registered callbacks. When a @ref Kokkos callback call is made,
+ * to set the @c Kokkos callback function pointers to this class's dispatching functions for the
+ * event types for which there are registered callbacks. When a @c Kokkos callback call is made,
  * these dispatching functions call the context callback first and then sequentially the registered
  * callbacks for the event type.
  *
  * On finalization, this class clears the list of registered callable objects and restores the
- * @ref Kokkos callback function pointers to the values they had prior to initializing this class.
+ * @c Kokkos callback function pointers to the values they had prior to initializing this class.
  *
- * @note The profiling callback calls are implemented in @ref Kokkos in terms of C function pointers.
+ * @note The profiling callback calls are implemented in @c Kokkos in terms of C function pointers.
  *       Class member functions cannot be converted to such C function pointers, unless they are
  *       static. This class is thus implemented as a singleton, and the dispatching functions are
  *       static member functions.
@@ -152,7 +152,7 @@ public:
 protected:
     /**
      * @brief Constructor. Retrieves and stores the @c Kokkos::Tools::Experimental::EventSet containing
-     *        the @ref Kokkos callback function pointers.
+     *        the @c Kokkos callback function pointers.
      */
     Manager() : context_callbacks(Kokkos::Tools::Experimental::get_callbacks()) {}
 
@@ -234,7 +234,7 @@ public:
 
 private:
     /**
-     * @brief Uses @c Kokkos::Tools::Experimental::set_callbacks to restore the @ref Kokkos callback
+     * @brief Uses @c Kokkos::Tools::Experimental::set_callbacks to restore the @c Kokkos callback
      *        function pointers to those retrieved on this class's initialization.
      */
     void reset_context_callbacks() const {
@@ -268,7 +268,7 @@ private:
 
     /**
      * @brief Uses the setters @c Kokkos::Tools::Experimental::set_<event_type_name>_callback
-     *        to set the @ref Kokkos callback function pointers to this class's dispatching functions
+     *        to set the @c Kokkos callback function pointers to this class's dispatching functions
      *        for the event types for which there are registered callbacks.
      */
     void set_dispatching_callbacks() const
@@ -289,7 +289,7 @@ private:
     }
 
     /// @note We don't forward in the templated lambda because the signature must be the one
-    ///       of the @ref Kokkos callback function pointers which pass by value.
+    ///       of the @c Kokkos callback function pointers which pass by value.
     template <Event EventType>
     static auto create_dispatching_callback_for_event_type_impl()
     {

--- a/include/kokkos-utils/callbacks/RecorderListener.hpp
+++ b/include/kokkos-utils/callbacks/RecorderListener.hpp
@@ -16,9 +16,9 @@ template <typename...>
 class RecorderListener;
 
 /**
- * @brief Listener for recording @ref Kokkos profiling callback calls.
+ * @brief Listener for recording @c Kokkos profiling callback calls.
  *
- * Records the @ref Kokkos profiling callback call that are represented by one
+ * Records the @c Kokkos profiling callback call that are represented by one
  * of the types @p EventTypes... and satisfy @p Matcher. The recorded events
  * are pushed back into a container in the order they are received.
  */

--- a/include/kokkos-utils/concepts/ExecutionSpace.hpp
+++ b/include/kokkos-utils/concepts/ExecutionSpace.hpp
@@ -6,7 +6,7 @@
 namespace Kokkos::utils::concepts
 {
 
-//! Specify that a type is a @ref Kokkos execution space.
+//! Specify that a type is a @c Kokkos execution space.
 template <typename T>
 concept ExecutionSpace = Kokkos::is_execution_space_v<T>;
 

--- a/include/kokkos-utils/concepts/MemorySpace.hpp
+++ b/include/kokkos-utils/concepts/MemorySpace.hpp
@@ -6,7 +6,7 @@
 namespace Kokkos::utils::concepts
 {
 
-//! Specify that a type is a @ref Kokkos memory space.
+//! Specify that a type is a @c Kokkos memory space.
 template <typename T>
 concept MemorySpace = Kokkos::is_memory_space_v<T>;
 

--- a/include/kokkos-utils/concepts/Space.hpp
+++ b/include/kokkos-utils/concepts/Space.hpp
@@ -6,7 +6,7 @@
 namespace Kokkos::utils::concepts
 {
 
-//! Specify that a type is a @ref Kokkos space.
+//! Specify that a type is a @c Kokkos space.
 template <typename T>
 concept Space = Kokkos::is_space<T>::value;
 

--- a/tests/callbacks/test_Events.cpp
+++ b/tests/callbacks/test_Events.cpp
@@ -14,7 +14,7 @@
  * -------------------------
  *
  * This group of tests check the behavior of the event types defined in @ref Events.hpp
- * associated with @ref Kokkos profiling callbacks.
+ * associated with @c Kokkos profiling callbacks.
  */
 
 using execution_space = Kokkos::DefaultExecutionSpace;
@@ -246,10 +246,10 @@ TYPED_TEST(EventTest, get_and_set_callback_from_and_in_eventset)
     const auto callback_to_register = [] <typename... Args>(Args...) -> void {};
     static_assert(std::convertible_to<decltype(callback_to_register), callback_fptr_t>);
 
-    //! Set the new callback in @ref Kokkos (thus replacing the context callback).
+    //! Set the new callback in @c Kokkos (thus replacing the context callback).
     get_callback_setter<TypeParam>()(callback_to_register);
 
-    //! Check that the callback was set in @ref Kokkos as expected.
+    //! Check that the callback was set in @c Kokkos as expected.
     ASSERT_EQ(get_callback_from_eventset<TypeParam>(Kokkos::Tools::Experimental::get_callbacks()), callback_to_register);
 
     //! Reset the context callback in @ref Kokkos.

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -23,7 +23,7 @@
  * ---------------------------
  *
  * This group of tests check the behavior of the matchers that can act as predicates
- * for the events associated with @ref Kokkos profiling callbacks.
+ * for the events associated with @c Kokkos profiling callbacks.
  */
 
 using execution_space = Kokkos::DefaultExecutionSpace;

--- a/tests/concepts/test_ExecutionSpace.cpp
+++ b/tests/concepts/test_ExecutionSpace.cpp
@@ -14,7 +14,7 @@ using execution_space = Kokkos::DefaultExecutionSpace;
  * Concepts related to execution space
  * -----------------------------------
  *
- * This group of tests check the behavior of our concepts related to @ref Kokkos execution space.
+ * This group of tests check the behavior of our concepts related to @c Kokkos execution space.
  */
 
 namespace Kokkos::utils::tests::concepts

--- a/tests/concepts/test_MemorySpace.cpp
+++ b/tests/concepts/test_MemorySpace.cpp
@@ -14,7 +14,7 @@ using execution_space = Kokkos::DefaultExecutionSpace;
  * Concepts related to memory space
  * --------------------------------
  *
- * This group of tests check the behavior of our concepts related to @ref Kokkos memory space.
+ * This group of tests check the behavior of our concepts related to @c Kokkos memory space.
  */
 
 namespace Kokkos::utils::tests::concepts

--- a/tests/concepts/test_Space.cpp
+++ b/tests/concepts/test_Space.cpp
@@ -14,7 +14,7 @@ using execution_space = Kokkos::DefaultExecutionSpace;
  * Concepts related to space
  * -------------------------
  *
- * This group of tests check the behavior of our concepts related to @ref Kokkos space.
+ * This group of tests check the behavior of our concepts related to @c Kokkos space.
  */
 
 namespace Kokkos::utils::tests::concepts


### PR DESCRIPTION
This PR follows from the Trilinos repository no longer publishing the Doxygen tag files.

As we don't use @ref for references to Kokkos things, except for the name itself, we decided to discard the tag file, and replace the remaining @ref Kokkos with @c Kokkos.

- https://github.com/trilinos/Trilinos/issues/14836