### PR TITLE
CICD: Workflow concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ on:
         # let's start the scheduled action at a somewhat random time to avoid periods of high load.
         - cron: '42 5 * * 3'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
     REGISTRY: ghcr.io
 


### PR DESCRIPTION
Let a new push to a pull request cancel a workflow still running for a previous push.
