### PR TITLE
cicd: disable multi-arch build (too slow)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,13 +61,50 @@ jobs:
                   echo "    - any changed: ${ANY_CHANGED}"
                   echo "build-images=${BUILD_IMAGES}" >> $GITHUB_OUTPUT
 
-    build-images:
+    build-images-image:
         needs: [set-vars-and-skips]
         if: ${{ needs.set-vars-and-skips.outputs.build-images == 'true' }}
-        runs-on: [ubuntu-latest]
+        runs-on: ubuntu-latest
         container:
             image: docker:latest
         permissions:
+            contents: read
+            packages: write
+        steps:
+            - uses: actions/checkout@v6
+
+            - uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - uses: docker/setup-qemu-action@v3
+
+            - uses: docker/setup-buildx-action@v3
+
+            - uses: docker/build-push-action@v6.18.0
+              with:
+                  context: null
+                  platforms: linux/amd64,linux/arm64
+                  push: ${{ github.ref == 'refs/heads/develop' }}
+                  file: docker/dockerfile.build-images
+                  tags: ghcr.io/${{ github.repository }}/build-images:latest
+                  cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/build-images:latest
+                  cache-to: type=inline
+                  labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
+
+    build-images:
+        needs: [set-vars-and-skips, build-images-image]
+        if: ${{ needs.set-vars-and-skips.outputs.build-images == 'true' }}
+        runs-on: ${{ matrix.runs-on }}
+        container:
+            image: ghcr.io/${{ github.repository }}/build-images:latest
+        services:
+            docker:
+                image: docker:dind
+        permissions:
+            contents: read
             packages: write
         strategy:
             fail-fast: false
@@ -79,20 +116,31 @@ jobs:
                       tag_suffix     : -13.1.0
                       platforms      : linux/amd64
                       kokkos_arch    : BLACKWELL120
+                      runs-on        : ubuntu-latest
                     - backend        : HIP
                       compiler_family: rocm
                       base_image     : rocm/dev-ubuntu-24.04:6.4.3
                       tag_suffix     : -6.4.3
                       platforms      : linux/amd64
                       kokkos_arch    : AMD_GFX906
+                      runs-on        : ubuntu-latest
                     - backend        : OpenMP
                       compiler_family: gcc
                       base_image     : ubuntu:24.04
-                      platforms      : linux/amd64,linux/arm64
+                      platforms      : linux/amd64
+                      tag_suffix     : -amd64
+                      runs-on        : ubuntu-latest
+                    - backend        : OpenMP
+                      compiler_family: gcc
+                      base_image     : ubuntu:24.04
+                      platforms      : linux/arm64
+                      runs-on        : ubuntu-24.04-arm
+                      tag_suffix     : -arm64
                     - backend        : OpenMP
                       compiler_family: clang
                       base_image     : ubuntu:24.04
                       platforms      : linux/amd64
+                      runs-on        : ubuntu-latest
         steps:
             - uses: actions/checkout@v6
               with:
@@ -108,9 +156,6 @@ jobs:
                   echo "DOXYGEN_VERSION=$(   jq .dependencies.doxygen.value    version.json -j)" >> $GITHUB_ENV
                   echo "GOOGLETEST_VERSION=$(jq .dependencies.googletest.value version.json -j)" >> $GITHUB_ENV
                   echo "KOKKOS_SHA=$(        jq .dependencies.kokkos.sha       version.json -j)" >> $GITHUB_ENV
-
-            - name: Set up QEMU.
-              uses: docker/setup-qemu-action@v3
 
             - name: Set up Docker Buildx.
               uses: docker/setup-buildx-action@v3

--- a/docker/dockerfile.build-images
+++ b/docker/dockerfile.build-images
@@ -1,0 +1,11 @@
+FROM ubuntu:24.04@sha256:66460d557b25769b102175144d538d88219c077c678a49af4afca6fbfc1b5252
+
+RUN <<EOF
+    set -ex
+
+    apt update
+
+    apt --yes install docker.io
+
+    apt clean && rm -rf /var/lib/apt/lists/*
+EOF


### PR DESCRIPTION
For now, let's just not have a multi-architecture image. I'll fix this in a followup.