### PR TITLE
cicd: test with arm64 and use GH runner for amd64 (gcc-openmp)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,7 +219,7 @@ jobs:
 
     build-library-and-test:
         needs: [set-vars-and-skips, finalize-images]
-        runs-on: ${{ matrix.runs_on || 'ubuntu-latest' }}
+        runs-on: ${{ matrix.runs-on }}
         if: ${{ ! failure() && ! cancelled() }}
         strategy:
             fail-fast: false
@@ -227,20 +227,30 @@ jobs:
                 include:
                     - backend        : Cuda
                       compiler_family: gcc
-                      runs_on        : [self-hosted, linux, amd64, docker, cuda, blackwell120]
+                      runs-on        : [self-hosted, linux, amd64, docker, cuda, blackwell120]
                       tag_suffix     : -13.1.0
+                      platform       : linux/amd64
                     - backend        : HIP
                       compiler_family: rocm
-                      runs_on        : [self-hosted, linux, amd64, docker, rocm, amd_gfx906]
+                      runs-on        : [self-hosted, linux, amd64, docker, rocm, amd_gfx906]
                       tag_suffix     : -6.4.3
+                      platform       : linux/amd64
                       options        : --device /dev/kfd --device /dev/dri
                     - backend        : OpenMP
                       compiler_family: gcc
+                      runs-on        : ubuntu-24.04
+                      platform       : linux/amd64
+                    - backend        : OpenMP
+                      compiler_family: gcc
+                      runs-on        : ubuntu-24.04-arm
+                      platform       : linux/arm64
                     - backend        : OpenMP
                       compiler_family: clang
+                      runs-on        : ubuntu-latest
+                      platform       : linux/amd64
         container:
             image: ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler_family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
-            options: --platform=linux/amd64 ${{ matrix.options }}
+            options: --platform=${{ matrix.platform }} ${{ matrix.options }}
         steps:
             - uses: actions/checkout@v6
 


### PR DESCRIPTION
* Use GitHub runners for the amd64 gcc-OpenMP test job
* Use GitHub runners to test for arm64 (new!)