### PR TITLE
callbacks(manager): null check before `delete` in finalize method

### DIFF
--- a/include/kokkos-utils/callbacks/Manager.hpp
+++ b/include/kokkos-utils/callbacks/Manager.hpp
@@ -158,7 +158,7 @@ protected:
 
 public:
     static void initialize() { singleton = new Manager(); }
-    static void finalize()   { delete singleton; }
+    static void finalize()   { if(singleton) delete singleton; }
 
     static Manager& get_instance() { return *singleton; }
 


### PR DESCRIPTION
I have a case with 2 objects that derive from the scoped manager, and when they both get out of scope, it would call `delete` twice.