### PR TITLE
Refactor singleton initialization and finalization

### DIFF
--- a/include/kokkos-utils/callbacks/Manager.hpp
+++ b/include/kokkos-utils/callbacks/Manager.hpp
@@ -157,8 +157,8 @@ protected:
     Manager() : context_callbacks(Kokkos::Tools::Experimental::get_callbacks()) {}
 
 public:
-    static void initialize() { singleton = new Manager(); }
-    static void finalize()   { if(singleton) delete singleton; }
+    static void initialize() { if(singleton == nullptr) singleton = new Manager(); }
+    static void finalize()   { if(singleton != nullptr) { delete singleton; singleton = nullptr; }}
 
     static Manager& get_instance() { return *singleton; }
 


### PR DESCRIPTION
It needs to be set back to `nullptr`, otherwise subsequent calls to `finalize` would delete something that's already deleted.

Note that our implementation is not thread-safe on purpose, because we want it to have the least overhead while profiling.