### PR TITLE
callbacks: add recorded event type alias

### DIFF
--- a/include/kokkos-utils/callbacks/RecorderListener.hpp
+++ b/include/kokkos-utils/callbacks/RecorderListener.hpp
@@ -28,6 +28,7 @@ class RecorderListener<MatcherType, EventTypes...>
 public:
     using matcher_t         = MatcherType;
     using event_type_list_t = Kokkos::Impl::type_list<EventTypes...>;
+    using event_variant_t   = std::variant<EventTypes...>;
 
 public:
     RecorderListener() = default;
@@ -77,7 +78,7 @@ public:
      * @note We use a @c std::deque because it can automatically expand when needed (whereas
      *       @c std::vector requires a reallocation and a copy).
      */
-    std::deque<std::variant<EventTypes...>> recorded_events {};
+    std::deque<event_variant_t> recorded_events {};
 
 private:
     MatcherType matcher {};

--- a/tests/callbacks/test_RecorderListener.cpp
+++ b/tests/callbacks/test_RecorderListener.cpp
@@ -79,7 +79,9 @@ TEST_F(RecorderListenerTest, recorded_events)
     EventInProfileSectionMatcher matcher{.matcher = EventRegexMatcher{.regex = std::regex("profile section")}};
     const auto recorder = std::make_shared<event_in_profile_section_recorder_t>(std::move(matcher));
 
-    const auto any_event_recorder = std::make_shared<RecorderListener<EventTypeList>>();
+    using recorder_t = RecorderListener<EventTypeList>;
+
+    const auto any_event_recorder = std::make_shared<recorder_t>();
 
     Kokkos::utils::callbacks::Manager::register_listener(recorder);
     Kokkos::utils::callbacks::Manager::register_listener(any_event_recorder);
@@ -94,7 +96,7 @@ TEST_F(RecorderListenerTest, recorded_events)
 
     ASSERT_THAT(
         recorder->recorded_events,
-        ContainsInOrder<typename decltype(recorder->recorded_events)::value_type>(
+        ContainsInOrder<typename recorder_t::event_variant_t>(
             APushRegionEventWithName(::testing::StrEq("computation - level 0")),
             ABeginParallelForEventWithName(::testing::StrEq("computation - level 0 - pfor")),
             AEndParallelForEvent(),


### PR DESCRIPTION
To ease using the type in the matchers.
