### PR TITLE
callbacks: allow user-defined (custom) events

### DIFF
--- a/include/kokkos-utils/callbacks/Events.hpp
+++ b/include/kokkos-utils/callbacks/Events.hpp
@@ -211,9 +211,12 @@ using EventTypeList = Kokkos::Impl::type_list<
 
 //! @name Concepts to constrain event types of similar nature.
 ///@{
-//! Concept to constrain any event type in @ref Kokkos::utils::callbacks::EventTypeList.
+//! Concept to constrain any event type.
 template <typename T>
-concept Event = impl::type_list_contains_v<T, EventTypeList>;
+concept Event = std::default_initializable<T>
+    && std::copyable<T>
+    && std::movable<T>
+    && std::equality_comparable<T>;
 
 //! Concept to constrain any begin event type.
 template <typename EventType>
@@ -313,12 +316,6 @@ constexpr auto get_name() {
     return Kokkos::Impl::TypeInfo<T>::name().substr(26);
 }
 
-template <Event EventType>
-std::ostream& operator<<(std::ostream &out, const EventType& /* event */) {
-    return out << get_name<EventType>() << ": "
-               << "{}";
-}
-
 template <BeginEvent EventType>
 std::ostream& operator<<(std::ostream &out, const EventType& event) {
     return out << get_name<EventType>() << ": "
@@ -346,6 +343,11 @@ inline std::ostream& operator<<(std::ostream &out, const BeginDeepCopyEvent& eve
                << "dst = "  << std::quoted(dst.name) << " (" << dst.kpsh.name << ", " << dst.ptr << ") of size " << src.size << "}";
 }
 
+inline std::ostream& operator<<(std::ostream &out, const EndDeepCopyEvent& /* event */) {
+    return out << get_name<EndDeepCopyEvent>() << ": "
+               << "{}";
+}
+
 inline std::ostream& operator<<(std::ostream &out, const CreateProfileSectionEvent& event) {
     return out << get_name<CreateProfileSectionEvent>() << ": "
                << "{name = " << std::quoted(event.name) << ", section_id = " << event.section_id << "}";
@@ -360,6 +362,11 @@ std::ostream& operator<<(std::ostream &out, const EventType& event) {
 inline std::ostream& operator<<(std::ostream &out, const PushRegionEvent& event) {
     return out << get_name<PushRegionEvent>() << ": "
                << "{name = " << std::quoted(event.name) << "}";
+}
+
+inline std::ostream& operator<<(std::ostream &out, const PopRegionEvent& /* event */) {
+    return out << get_name<PopRegionEvent>() << ": "
+               << "{}";
 }
 
 inline std::ostream& operator<<(std::ostream &out, const ProfileEvent& event) {

--- a/include/kokkos-utils/callbacks/Helpers.hpp
+++ b/include/kokkos-utils/callbacks/Helpers.hpp
@@ -13,16 +13,18 @@ namespace Kokkos::utils::callbacks
                                   public scoped::callbacks::Manager {}; \
     TEST_F(__test_fixture_name__, __test_name__)
 
-#define DEFINE_EVENT_MATCHER(__eventtype__)                                                                  \
+#define DEFINE_EVENT_MATCHER_IN(__namespace__, __eventtype__)                                                \
     template <typename... Matchers>                                                                          \
     auto A##__eventtype__(Matchers&&... matchers)                                                            \
     {                                                                                                        \
-        using EventType = Kokkos::utils::callbacks::__eventtype__;                                           \
+        using EventType = __namespace__::__eventtype__;                                                      \
         if constexpr (sizeof...(Matchers) == 0)                                                              \
             return ::testing::VariantWith<EventType>(::testing::_);                                          \
         else                                                                                                 \
             return ::testing::VariantWith<EventType>(::testing::AllOf(std::forward<Matchers>(matchers)...)); \
     }
+
+#define DEFINE_EVENT_MATCHER(__eventtype__) DEFINE_EVENT_MATCHER_IN(Kokkos::utils::callbacks, __eventtype__)
 
 DEFINE_EVENT_MATCHER(BeginParallelForEvent)
 DEFINE_EVENT_MATCHER(EndParallelForEvent)
@@ -44,13 +46,15 @@ DEFINE_EVENT_MATCHER(PushRegionEvent)
 DEFINE_EVENT_MATCHER(PopRegionEvent)
 DEFINE_EVENT_MATCHER(ProfileEvent)
 
-#define DEFINE_EVENT_WITH_NAME_MATCHER(__eventtype__)                                                                 \
+#define DEFINE_EVENT_WITH_NAME_MATCHER_IN(__namespace__, __eventtype__)                                               \
     template <typename Matcher>                                                                                       \
     auto A##__eventtype__##WithName(Matcher&& matcher)                                                                \
     {                                                                                                                 \
-        using EventType = Kokkos::utils::callbacks::__eventtype__;                                                    \
+        using EventType = __namespace__::__eventtype__;                                                               \
         return ::testing::VariantWith<EventType>(::testing::Field(&EventType::name, std::forward<Matcher>(matcher))); \
     }
+
+#define DEFINE_EVENT_WITH_NAME_MATCHER(__eventtype__) DEFINE_EVENT_WITH_NAME_MATCHER_IN(Kokkos::utils::callbacks, __eventtype__)
 
 DEFINE_EVENT_WITH_NAME_MATCHER(BeginParallelForEvent)
 DEFINE_EVENT_WITH_NAME_MATCHER(BeginParallelReduceEvent)

--- a/include/kokkos-utils/callbacks/Listener.hpp
+++ b/include/kokkos-utils/callbacks/Listener.hpp
@@ -21,14 +21,47 @@ struct IsListenerFor
     using type = std::is_invocable_r<void, Callable, const EventType&>;
 };
 
+template <typename T>
+concept has_event_type_list = requires { typename T::event_type_list_t; };
+
+template <typename Callable>
+struct ListenerEventTypeList
+{
+    using type = Kokkos::Impl::filter_type_list_t<
+        impl::IsListenerFor<Callable>::template type, EventTypeList>;
+};
+
+template <has_event_type_list Callable>
+struct ListenerEventTypeList<Callable>
+{
+    using type = typename Callable::event_type_list_t;
+};
+
+/**
+ * A @p Callable can be treated *implicitly* as a listener if it is invocable with at least one event type
+ * from @ref Kokkos::utils::callbacks::EventTypeList passed by @c const reference and returns @c void.
+ */
+template <typename Callable>
+concept ImplicitListener = Kokkos::utils::impl::type_list_any_v<impl::IsListenerFor<Callable>::template type, EventTypeList>;
+
+/**
+ * A @p Callable can be treated as a listener if it models @ref Kokkos::utils::callbacks::impl::has_event_type_list
+ * and it is callable for each of the event types in the list passed by @c const reference and returns @c void.
+ */
+template <typename Callable>
+concept ExplicitListener = has_event_type_list<Callable> &&
+    Kokkos::utils::impl::type_list_all_v<
+        impl::IsListenerFor<Callable>::template type,
+        typename Callable::event_type_list_t
+    >;
 } // namespace impl
 
 /**
- * @brief @p Callable is a listener if it is invocable with at least one event type
- *        from @ref Kokkos::utils::callbacks::EventTypeList passed by @c const reference and returns @c void.
+ * A @p Callable is a listener if it satisfies either @ref Kokkos::utils::callbacks::impl::ExplicitListener
+ * or @ref Kokkos::utils::callbacks::impl::ImplicitListener.
  */
 template <typename Callable>
-concept Listener = Kokkos::utils::impl::type_list_any_v<impl::IsListenerFor<Callable>::template type, EventTypeList>;
+concept Listener = impl::ExplicitListener<Callable> || impl::ImplicitListener<Callable>;
 
 //! Check that @p Callable is a listener for each event in @p EventTypes.
 template <typename Callable, typename... EventTypes>
@@ -36,7 +69,7 @@ concept ListenerFor = Kokkos::utils::impl::type_list_all_v<impl::IsListenerFor<C
 
 //! Type list holding the event types that @p Callable can be a listener for.
 template <typename Callable>
-using listener_event_type_list_t = Kokkos::Impl::filter_type_list_t<impl::IsListenerFor<Callable>::template type, EventTypeList>;
+using listener_event_type_list_t = typename impl::ListenerEventTypeList<Callable>::type;
 
 } // namespace Kokkos::utils::callbacks
 

--- a/include/kokkos-utils/callbacks/Manager.hpp
+++ b/include/kokkos-utils/callbacks/Manager.hpp
@@ -1,6 +1,7 @@
 #ifndef KOKKOS_UTILS_CALLBACKS_MANAGER_HPP
 #define KOKKOS_UTILS_CALLBACKS_MANAGER_HPP
 
+#include <atomic>
 #include <list>
 #include <ranges>
 
@@ -211,9 +212,11 @@ public:
         );
 
         Kokkos::utils::impl::for_each<event_type_list_t>([&] <Event EventType>() {
-            get<Kokkos::utils::impl::type_list_index_v<EventType, EventTypeList>>(get_instance().registered_callbacks).remove(
-                dynamic_cast<const impl::ListenerConceptCallOperator<EventType>*>(iter->get())
-            );
+            if constexpr(Kokkos::utils::impl::type_list_contains_v<EventType, EventTypeList>) {
+                get<Kokkos::utils::impl::type_list_index_v<EventType, EventTypeList>>(get_instance().registered_callbacks).remove(
+                    dynamic_cast<const impl::ListenerConceptCallOperator<EventType>*>(iter->get())
+                );
+            }
         });
 
         listeners.erase(iter);
@@ -232,6 +235,26 @@ public:
         get_instance().listeners.erase(iter);
 
         get_instance().set_dispatching_callbacks();
+    }
+
+    //! Dispatch the event to all registered listeners that can handle it.
+    template <Event EventType>
+    void dispatch(const EventType& event) const {
+        for (auto& listener: this->listeners) {
+            if (const auto* const callable = dynamic_cast<const impl::ListenerConceptCallOperator<EventType>*>(listener.get()); callable != nullptr) {
+                callable->operator()(event);
+            }
+        }
+    }
+
+    //! Get the next available event ID.
+    uint64_t get_next_event_id() noexcept {
+        return next_event_id.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    //! Get the next available section ID.
+    uint32_t get_next_section_id() noexcept {
+        return next_section_id.fetch_add(1, std::memory_order_relaxed);
     }
 
 private:
@@ -258,9 +281,11 @@ private:
         /// For each event type that the callable object can be invoked with, store the raw pointer
         /// to the listener model in the list of listeners for this event type.
         Kokkos::utils::impl::for_each<event_type_list_t>([&] <Event EventType>() {
-            get<Kokkos::utils::impl::type_list_index_v<EventType, EventTypeList>>(get_instance().registered_callbacks).push_back(
-                dynamic_cast<const impl::ListenerConceptCallOperator<EventType>*>(iter->get())
-            );
+            if constexpr(Kokkos::utils::impl::type_list_contains_v<EventType, EventTypeList>) {
+                get<Kokkos::utils::impl::type_list_index_v<EventType, EventTypeList>>(get_instance().registered_callbacks).push_back(
+                    dynamic_cast<const impl::ListenerConceptCallOperator<EventType>*>(iter->get())
+                );
+            }
         });
 
         get_instance().set_dispatching_callbacks();
@@ -428,11 +453,11 @@ private:
 
     template <BeginEvent EventType>
     void increment_id_if_needed_for_event_type_impl(EventType& event) {
-        event.event_id = next_event_id++;
+        event.event_id = this->get_next_event_id();
     }
 
     void increment_id_if_needed_for_event_type_impl(CreateProfileSectionEvent& event) {
-        event.section_id = next_section_id++;
+        event.section_id = this->get_next_section_id();
     }
 
     template <Event EventType>
@@ -452,9 +477,22 @@ private:
 
     Kokkos::Tools::Experimental::EventSet context_callbacks {};
 
-    uint64_t next_event_id   = 0;
-    uint32_t next_section_id = 0;
+    std::atomic<uint64_t> next_event_id{0};
+    std::atomic<uint32_t> next_section_id{0};
 };
+
+template <Event EventType>
+void dispatch(const EventType& event) {
+    Manager::get_instance().dispatch(event);
+}
+
+inline uint64_t get_next_event_id() noexcept {
+    return Manager::get_instance().get_next_event_id();
+}
+
+inline uint32_t get_next_section_id() noexcept {
+    return Manager::get_instance().get_next_section_id();
+}
 
 } // namespace Kokkos::utils::callbacks
 

--- a/include/kokkos-utils/callbacks/RecorderListener.hpp
+++ b/include/kokkos-utils/callbacks/RecorderListener.hpp
@@ -3,6 +3,7 @@
 
 #include <deque>
 #include <functional>
+#include <mutex>
 #include <variant>
 
 #include "kokkos-utils/callbacks/Listener.hpp"
@@ -37,9 +38,18 @@ public:
     explicit RecorderListener(T&& matcher_)
       : matcher(std::forward<T>(matcher_)) {}
 
+    RecorderListener(const RecorderListener&)            = delete;
+    RecorderListener& operator=(const RecorderListener&) = delete;
+    RecorderListener(RecorderListener&&)                 = delete;
+    RecorderListener& operator=(RecorderListener&&)      = delete;
+
+    //! Ensure atomic growth of @ref recorded_events with @ref mtx.
     template <EventOneOf<EventTypes...> EventType>
     void operator()(const EventType& event) {
-        if (matcher(event)) this->recorded_events.push_back(event);
+        if (matcher(event)) {
+            std::lock_guard lock(mtx);
+            recorded_events.push_back(event);
+        }
     }
 
     /**
@@ -82,6 +92,7 @@ public:
 
 private:
     MatcherType matcher {};
+    mutable std::mutex mtx;
 };
 
 template <typename MatcherType, Event... EventTypes>

--- a/tests/callbacks/test_RecorderListener.cpp
+++ b/tests/callbacks/test_RecorderListener.cpp
@@ -204,4 +204,104 @@ TEST_F_WITH_CB_MGR(FenceFinderTest, recorded_events)
     Kokkos::utils::callbacks::Manager::unregister_listener(fence_finder.get());
 }
 
+struct CustomEvent {
+    uint64_t event_id = 0;
+
+    bool operator==(const CustomEvent&) const = default;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const CustomEvent& event) {
+    return out << "CustomEvent: " << "{event_id = " << event.event_id << "}";
+}
+
+struct CustomEventWithPayload {
+    std::string payload {};
+    uint64_t event_id = 0;
+
+    bool operator==(const CustomEventWithPayload&) const = default;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const CustomEventWithPayload& event) {
+    return out << "CustomEventWithPayload: " << "{payload = " << event.payload << ", event_id = " << event.event_id << "}";
+}
+
+static_assert(Kokkos::utils::callbacks::Event<CustomEvent>);
+static_assert(Kokkos::utils::callbacks::Event<CustomEventWithPayload>);
+
+DEFINE_EVENT_MATCHER_IN(Kokkos::utils::tests::callbacks, CustomEvent)
+DEFINE_EVENT_MATCHER_IN(Kokkos::utils::tests::callbacks, CustomEventWithPayload)
+
+//! @test Check the behavior of @ref Kokkos::utils::callbacks::RecorderListener<MatcherType, EventTypes...>::record with a mix of @c Kokkos and custom events.
+TEST_F(RecorderListenerTest, record_mix_kokkos_and_custom_events) {
+    using recorder_listener_t = RecorderListener<BeginParallelForEvent, CustomEvent, CustomEventWithPayload>;
+
+    static_assert(std::same_as<
+        Kokkos::utils::callbacks::listener_event_type_list_t<recorder_listener_t>,
+        Kokkos::Impl::type_list<BeginParallelForEvent, CustomEvent, CustomEventWithPayload>
+    >);
+
+    static_assert(Kokkos::utils::callbacks::impl::ImplicitListener<recorder_listener_t>);
+    static_assert(Kokkos::utils::callbacks::impl::ExplicitListener<recorder_listener_t>);
+    static_assert(Kokkos::utils::callbacks::Listener<recorder_listener_t>);
+    static_assert(Kokkos::utils::callbacks::ListenerFor<recorder_listener_t, BeginParallelForEvent, CustomEvent, CustomEventWithPayload>);
+
+    ASSERT_THAT(
+        (recorder_listener_t::record([&exec = this->exec]{
+            MyWorkload<execution_space>{}.execute(exec);
+            Kokkos::utils::callbacks::dispatch(CustomEventWithPayload{
+                .payload = "My taylor is rich.",
+                .event_id = Kokkos::utils::callbacks::get_next_event_id()
+            });
+            Kokkos::utils::callbacks::dispatch(CustomEvent{
+                .event_id = Kokkos::utils::callbacks::get_next_event_id()
+            });
+        })),
+        ContainsInOrder<typename recorder_listener_t::event_variant_t>(
+            ABeginParallelForEvent(
+                ::testing::Field(&BeginParallelForEvent::name, ::testing::StrEq("computation - level 0 - pfor")),
+                ::testing::Field(&BeginParallelForEvent::dev_id, ::testing::Eq(Kokkos::Tools::Experimental::device_id(this->exec))),
+                ::testing::Field(&BeginParallelForEvent::event_id, ::testing::Eq(0))
+            ),
+            ACustomEventWithPayload(
+                ::testing::Field(&CustomEventWithPayload::payload, ::testing::StrEq("My taylor is rich.")),
+                ::testing::Field(&CustomEventWithPayload::event_id, ::testing::Eq(1))
+            ),
+            ACustomEvent(
+                ::testing::Field(&CustomEvent::event_id, ::testing::Eq(2))
+            )
+        )
+    );
+}
+
+//! @test Check the behavior of @ref Kokkos::utils::callbacks::RecorderListener<MatcherType, EventTypes...>::record with only a custom event.
+TEST_F(RecorderListenerTest, record_custom_event) {
+    using recorder_listener_t = RecorderListener<CustomEventWithPayload>;
+
+    static_assert(std::same_as<
+        Kokkos::utils::callbacks::listener_event_type_list_t<recorder_listener_t>,
+        Kokkos::Impl::type_list<CustomEventWithPayload>
+    >);
+
+    static_assert(!Kokkos::utils::callbacks::impl::ImplicitListener<recorder_listener_t>);
+    static_assert(Kokkos::utils::callbacks::impl::ExplicitListener<recorder_listener_t>);
+    static_assert(Kokkos::utils::callbacks::Listener<recorder_listener_t>);
+    static_assert(Kokkos::utils::callbacks::ListenerFor<recorder_listener_t, CustomEventWithPayload>);
+    static_assert(!Kokkos::utils::callbacks::ListenerFor<recorder_listener_t, CustomEvent>);
+
+    ASSERT_THAT(
+        (recorder_listener_t::record([]{
+            Kokkos::utils::callbacks::dispatch(CustomEventWithPayload{
+                .payload = "My taylor is rich.",
+                .event_id = Kokkos::utils::callbacks::get_next_event_id()
+            });
+        })),
+        ::testing::ElementsAre(
+            ACustomEventWithPayload(
+                ::testing::Field(&CustomEventWithPayload::payload, ::testing::StrEq("My taylor is rich.")),
+                ::testing::Field(&CustomEventWithPayload::event_id, ::testing::Eq(0))
+            )
+        )
+    );
+}
+
 } // namespace Kokkos::utils::tests::callbacks


### PR DESCRIPTION
This PR allows user-defined events to be treated as events.

The primary purpose is to let users define their own event types and allow them to be interleaved with `Kokkos` events in the final "queue" of recorded events.