### PR TITLE
cicd: compiler.family to prepare for compiler.version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,33 +111,38 @@ jobs:
             matrix:
                 include:
                     - backend        : Cuda
-                      compiler_family: gcc
+                      compiler:
+                        family: gcc
                       base_image     : nvcr.io/nvidia/cuda:13.1.0-devel-ubuntu24.04
                       tag_suffix     : -13.1.0
                       platforms      : linux/amd64
                       kokkos_arch    : BLACKWELL120
                       runs-on        : ubuntu-latest
                     - backend        : HIP
-                      compiler_family: rocm
+                      compiler:
+                        family: rocm
                       base_image     : rocm/dev-ubuntu-24.04:6.4.3
                       tag_suffix     : -6.4.3
                       platforms      : linux/amd64
                       kokkos_arch    : AMD_GFX906
                       runs-on        : ubuntu-latest
                     - backend        : OpenMP
-                      compiler_family: gcc
+                      compiler:
+                        family: gcc
                       base_image     : ubuntu:24.04
                       platforms      : linux/amd64
                       tag_suffix     : -amd64
                       runs-on        : ubuntu-latest
                     - backend        : OpenMP
-                      compiler_family: gcc
+                      compiler:
+                        family: gcc
                       base_image     : ubuntu:24.04
                       platforms      : linux/arm64
                       runs-on        : ubuntu-24.04-arm
                       tag_suffix     : -arm64
                     - backend        : OpenMP
-                      compiler_family: clang
+                      compiler:
+                        family: clang
                       base_image     : ubuntu:24.04
                       platforms      : linux/amd64
                       runs-on        : ubuntu-latest
@@ -172,18 +177,18 @@ jobs:
                   platforms: ${{ matrix.platforms }}
                   push: ${{ github.ref == 'refs/heads/develop' }}
                   file: docker/dockerfile
-                  tags: ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler_family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
-                  cache-from: type=registry,ref=${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler_family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
+                  tags: ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
+                  cache-from: type=registry,ref=${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
                   cache-to: type=inline
                   target: final
                   build-args: |
                       BASE_IMAGE=${{ matrix.base_image }}
                       CMAKE_VERSION=${{ env.CMAKE_VERSION }}
-                      COMPILER_FAMILY=${{ matrix.compiler_family }}
+                      COMPILER_FAMILY=${{ matrix.compiler.family }}
                       DOXYGEN_VERSION=${{ env.DOXYGEN_VERSION }}
                       GOOGLETEST_VERSION=${{ env.GOOGLETEST_VERSION }}
                       KOKKOS_ARCH=${{ matrix.kokkos_arch }}
-                      KOKKOS_PRESET=${{ matrix.compiler_family }}-${{ matrix.backend }}
+                      KOKKOS_PRESET=${{ matrix.compiler.family }}-${{ matrix.backend }}
                       KOKKOS_SHA=${{ env.KOKKOS_SHA }}
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 
@@ -202,8 +207,9 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - backend        : OpenMP
-                      compiler_family: gcc
+                    - backend: OpenMP
+                      compiler:
+                        family: gcc
         steps:
             - uses: docker/login-action@v4
               with:
@@ -213,9 +219,9 @@ jobs:
 
             - run: |
                 docker buildx imagetools create \
-                    --tag=${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler_family }}-${{ matrix.backend }}${{ matrix.tag_suffix }} \
-                    ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler_family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}-amd64 \
-                    ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler_family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}-arm64
+                    --tag=${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.backend }}${{ matrix.tag_suffix }} \
+                    ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}-amd64 \
+                    ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}-arm64
 
     build-library-and-test:
         needs: [set-vars-and-skips, finalize-images]
@@ -226,46 +232,51 @@ jobs:
             matrix:
                 include:
                     - backend        : Cuda
-                      compiler_family: gcc
+                      compiler:
+                        family: gcc
                       runs-on        : [self-hosted, linux, amd64, docker, cuda, blackwell120]
                       tag_suffix     : -13.1.0
                       platform       : linux/amd64
                     - backend        : HIP
-                      compiler_family: rocm
+                      compiler:
+                        family: rocm
                       runs-on        : [self-hosted, linux, amd64, docker, rocm, amd_gfx906]
                       tag_suffix     : -6.4.3
                       platform       : linux/amd64
                       options        : --device /dev/kfd --device /dev/dri
                     - backend        : OpenMP
-                      compiler_family: gcc
+                      compiler:
+                        family: gcc
                       runs-on        : ubuntu-24.04
                       platform       : linux/amd64
                     - backend        : OpenMP
-                      compiler_family: gcc
+                      compiler:
+                        family: gcc
                       runs-on        : ubuntu-24.04-arm
                       platform       : linux/arm64
                     - backend        : OpenMP
-                      compiler_family: clang
+                      compiler:
+                        family: clang
                       runs-on        : ubuntu-latest
                       platform       : linux/amd64
         container:
-            image: ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler_family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
+            image: ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
             options: --platform=${{ matrix.platform }} ${{ matrix.options }}
         steps:
             - uses: actions/checkout@v6
 
             - name: Configure and build.
               run : |
-                  cmake -S .    --preset=${{ matrix.compiler_family }}-${{ matrix.backend }} --warn-uninitialized -Werror=dev
-                  cmake --build --preset=${{ matrix.compiler_family }}-${{ matrix.backend }} -j$(($(nproc) > 4 ? 4 : $(nproc)))
+                  cmake -S .    --preset=${{ matrix.compiler.family }}-${{ matrix.backend }} --warn-uninitialized -Werror=dev
+                  cmake --build --preset=${{ matrix.compiler.family }}-${{ matrix.backend }} -j$(($(nproc) > 4 ? 4 : $(nproc)))
 
             - name: Test.
               run : |
-                  ctest --preset=${{ matrix.compiler_family }}-${{ matrix.backend }}
+                  ctest --preset=${{ matrix.compiler.family }}-${{ matrix.backend }}
 
             - name: Test install.
               run : |
-                  bash tests/install.sh ${{ matrix.compiler_family }}-${{ matrix.backend }}
+                  bash tests/install.sh ${{ matrix.compiler.family }}-${{ matrix.backend }}
 
             - name: Test find package after install.
               run : |
@@ -274,7 +285,7 @@ jobs:
                   test -d include/
                   rm -rf include/
 
-                  bash tests/find_package.sh "${{ matrix.compiler_family }}" "${KOKKOS_UTILS_VERSION}"
+                  bash tests/find_package.sh "${{ matrix.compiler.family }}" "${KOKKOS_UTILS_VERSION}"
 
     build-documentation:
         needs: [set-vars-and-skips, finalize-images]

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -122,7 +122,7 @@ RUN <<EOF
 
     cd googlebenchmark
 
-    git checkout 84b9b21a125b504864fa9876946207b3e8cb389d
+    git checkout f649efee480295b01a04bf077cdd50b3293d56c5
 
     cmake -S . -B build \
         -DCMAKE_INSTALL_PREFIX=/opt/google-benchmark-${GOOGLEBENCHMARK_VERSION} \

--- a/version.json
+++ b/version.json
@@ -10,7 +10,7 @@
             "value" : "1.13.2"
         },
         "googlebenchmark" : {
-            "value" : "1.9.4"
+            "value" : "1.9.5"
         },
         "googletest" : {
             "value" : "1.17.0"


### PR DESCRIPTION
This PR changes from `compiler_family` key to `compiler: {family: }` dictionary. A followup will add the version so we can have multiple versions of *e.g.* `clang`.