### PR TITLE
docker: allow any clang/gcc compiler version install

### DIFF
--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -1,16 +1,6 @@
-FROM ghcr.io/uliegecsm/kokkos-utils/kokkos-utils:gcc-OpenMP
+FROM ghcr.io/uliegecsm/kokkos-utils/kokkos-utils:clang-22-OpenMP
 
 # Install gpg and gnupg2 allows the container to use GPG keys to sign commits.
 # See also:
 #   - https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials
-RUN <<EOF
-
-    set -ex
-
-    apt update
-
-    apt --yes --no-install-recommends install gpg gnupg2
-
-    apt clean && rm -rf /var/lib/apt/lists/*
-
-EOF
+RUN apt-helpers install-packages --update --clean --packages gpg gnupg2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
                   files: |
                       .github/**
                       cmake/presets/**
-                      docker/dockerfile.builder
+                      docker/*
                       requirements/**
                       version.json
 
@@ -113,6 +113,7 @@ jobs:
                     - backend        : Cuda
                       compiler:
                         family: gcc
+                        version: 14
                       base_image     : nvcr.io/nvidia/cuda:13.1.0-devel-ubuntu24.04
                       tag_suffix     : -13.1.0
                       platforms      : linux/amd64
@@ -129,6 +130,7 @@ jobs:
                     - backend        : OpenMP
                       compiler:
                         family: gcc
+                        version: 14
                       base_image     : ubuntu:24.04
                       platforms      : linux/amd64
                       tag_suffix     : -amd64
@@ -136,6 +138,7 @@ jobs:
                     - backend        : OpenMP
                       compiler:
                         family: gcc
+                        version: 14
                       base_image     : ubuntu:24.04
                       platforms      : linux/arm64
                       runs-on        : ubuntu-24.04-arm
@@ -143,9 +146,17 @@ jobs:
                     - backend        : OpenMP
                       compiler:
                         family: clang
+                        version: 18
                       base_image     : ubuntu:24.04
                       platforms      : linux/amd64
                       runs-on        : ubuntu-latest
+                    - backend: OpenMP
+                      compiler:
+                        family: clang
+                        version: 22
+                      base_image: ubuntu:24.04
+                      platforms: linux/amd64
+                      runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
               with:
@@ -177,14 +188,15 @@ jobs:
                   platforms: ${{ matrix.platforms }}
                   push: ${{ github.ref == 'refs/heads/develop' }}
                   file: docker/dockerfile
-                  tags: ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
-                  cache-from: type=registry,ref=${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
+                  tags: ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.compiler.version }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
+                  cache-from: type=registry,ref=${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.compiler.version }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
                   cache-to: type=inline
                   target: final
                   build-args: |
                       BASE_IMAGE=${{ matrix.base_image }}
                       CMAKE_VERSION=${{ env.CMAKE_VERSION }}
                       COMPILER_FAMILY=${{ matrix.compiler.family }}
+                      COMPILER_VERSION=${{ matrix.compiler.version }}
                       DOXYGEN_VERSION=${{ env.DOXYGEN_VERSION }}
                       GOOGLETEST_VERSION=${{ env.GOOGLETEST_VERSION }}
                       KOKKOS_ARCH=${{ matrix.kokkos_arch }}
@@ -210,6 +222,7 @@ jobs:
                     - backend: OpenMP
                       compiler:
                         family: gcc
+                        version: 14
         steps:
             - uses: docker/login-action@v4
               with:
@@ -219,9 +232,9 @@ jobs:
 
             - run: |
                 docker buildx imagetools create \
-                    --tag=${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.backend }}${{ matrix.tag_suffix }} \
-                    ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}-amd64 \
-                    ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}-arm64
+                    --tag=${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.compiler.version }}-${{ matrix.backend }}${{ matrix.tag_suffix }} \
+                    ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.compiler.version }}-${{ matrix.backend }}${{ matrix.tag_suffix }}-amd64 \
+                    ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.compiler.version }}-${{ matrix.backend }}${{ matrix.tag_suffix }}-arm64
 
     build-library-and-test:
         needs: [set-vars-and-skips, finalize-images]
@@ -234,6 +247,7 @@ jobs:
                     - backend        : Cuda
                       compiler:
                         family: gcc
+                        version: 14
                       runs-on        : [self-hosted, linux, amd64, docker, cuda, blackwell120]
                       tag_suffix     : -13.1.0
                       platform       : linux/amd64
@@ -247,20 +261,29 @@ jobs:
                     - backend        : OpenMP
                       compiler:
                         family: gcc
+                        version: 14
                       runs-on        : ubuntu-24.04
                       platform       : linux/amd64
                     - backend        : OpenMP
                       compiler:
                         family: gcc
+                        version: 14
                       runs-on        : ubuntu-24.04-arm
                       platform       : linux/arm64
                     - backend        : OpenMP
                       compiler:
                         family: clang
+                        version: 18
+                      runs-on        : ubuntu-latest
+                      platform       : linux/amd64
+                    - backend        : OpenMP
+                      compiler:
+                        family: clang
+                        version: 22
                       runs-on        : ubuntu-latest
                       platform       : linux/amd64
         container:
-            image: ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
+            image: ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.compiler.version }}-${{ matrix.backend }}${{ matrix.tag_suffix }}
             options: --platform=${{ matrix.platform }} ${{ matrix.options }}
         steps:
             - uses: actions/checkout@v6
@@ -292,7 +315,7 @@ jobs:
         if: ${{ ! failure() && ! cancelled() }}
         runs-on: [ubuntu-latest]
         container:
-            image: ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:gcc-OpenMP
+            image: ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:gcc-14-OpenMP
         steps:
             - uses: actions/checkout@v6
 

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,6 +1,8 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=not-given
+ARG COMPILER_FAMILY=not-given
 
-FROM ${BASE_IMAGE} AS requirements
+# Install Python3 (with the trickery for virtual environment).
+FROM ${BASE_IMAGE} AS requirements-python
 
 ARG PYTHON_VERSION=3.12
 ENV VIRTUAL_ENV=/opt/venv-${PYTHON_VERSION}
@@ -20,27 +22,67 @@ RUN <<EOF
     apt-helpers clean
 EOF
 
-ARG COMPILER_FAMILY
+FROM requirements-python AS requirements-compiler-gcc
 
-# Install APT requirements.
-RUN --mount=target=/requirements,type=bind,source=requirements <<EOF
+ARG COMPILER_VERSION
+
+RUN <<EOF
     set -ex
 
-    if [ "${COMPILER_FAMILY}" = "gcc" ];then
-        COMPILER_FAMILY_REQUIREMENTS=g++
-    elif [ "${COMPILER_FAMILY}" = "clang" ];then
-        COMPILER_FAMILY_REQUIREMENTS="clang clang-tidy libomp-dev"
-    elif [ "${COMPILER_FAMILY}" = "rocm" ];then
-        COMPILER_FAMILY_REQUIREMENTS=""
-    else
-        echo "unsupported compiler family ${COMPILER_FAMILY}"
-        exit -1
-    fi
+    apt-helpers install-packages --clean --update --packages gcc-${COMPILER_VERSION} g++-${COMPILER_VERSION}
 
-    apt-helpers install-packages --clean --update  \
-        --packages ${COMPILER_FAMILY_REQUIREMENTS} \
+    update-alternatives-helpers --prefix /usr/bin \
+        --display --level=10 \
+        --for-each-of \
+            gcc=gcc-${COMPILER_VERSION} \
+            g++=g++-${COMPILER_VERSION} \
+            $(uname -m)-linux-gnu-gcc=$(uname -m)-linux-gnu-gcc-${COMPILER_VERSION} \
+            $(uname -m)-linux-gnu-g++=$(uname -m)-linux-gnu-g++-${COMPILER_VERSION}
+
+    gcc -dumpfullversion -dumpversion
+    g++ -dumpfullversion -dumpversion
+EOF
+
+FROM requirements-python AS requirements-compiler-rocm
+
+FROM requirements-python AS requirements-compiler-clang
+
+ARG COMPILER_VERSION
+
+RUN <<EOF
+    set -ex
+
+    apt-helpers install-packages --update --packages wget lsb-release gpg software-properties-common
+
+    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/llvm.asc
+    echo "deb https://apt.llvm.org/noble/ llvm-toolchain-noble-${COMPILER_VERSION} main" > /etc/apt/sources.list.d/llvm.list
+
+    apt-helpers install-packages --clean    \
+        --update --packages                 \
+        clang-${COMPILER_VERSION}           \
+        libclang-rt-${COMPILER_VERSION}-dev \
+        clang-tidy-${COMPILER_VERSION}      \
+        clang-format-${COMPILER_VERSION}    \
+        libomp-${COMPILER_VERSION}-dev
+
+    update-alternatives-helpers --prefix /usr/bin --level 10 \
+        --display --for-each-of                              \
+        clang=clang-${COMPILER_VERSION}                      \
+        clang++=clang++-${COMPILER_VERSION}                  \
+        clang-tidy=clang-tidy-${COMPILER_VERSION}            \
+        clang-format=clang-format-${COMPILER_VERSION}
+EOF
+
+FROM requirements-compiler-${COMPILER_FAMILY} AS requirements-system
+
+RUN --mount=target=/requirements/requirements.system.txt,type=bind,source=requirements/requirements.system.txt <<EOF
+    set -ex
+
+    apt-helpers install-packages --clean --update \
         --requirement /requirements/requirements.system.txt
 EOF
+
+FROM requirements-system AS requirements-cmake
 
 ARG CMAKE_VERSION
 ARG TARGETARCH
@@ -70,7 +112,7 @@ EOF
 ENV PATH=/opt/cmake-${CMAKE_VERSION}/bin:${PATH}
 
 # Compile Doxygen.
-FROM requirements AS doxygen-compile
+FROM requirements-cmake AS doxygen-compile
 
 ARG DOXYGEN_VERSION
 
@@ -91,7 +133,7 @@ RUN <<EOF
 EOF
 
 # Compile Google Test.
-FROM requirements AS google-test-compile
+FROM requirements-cmake AS google-test-compile
 
 ARG GOOGLETEST_VERSION
 
@@ -112,7 +154,7 @@ RUN <<EOF
 EOF
 
 # Compile Google Benchmark.
-FROM requirements AS google-benchmark-compile
+FROM requirements-cmake AS google-benchmark-compile
 
 ARG GOOGLEBENCHMARK_VERSION
 
@@ -137,7 +179,7 @@ RUN <<EOF
 EOF
 
 # Compile Kokkos.
-FROM requirements AS kokkos-compile
+FROM requirements-cmake AS kokkos-compile
 
 ARG KOKKOS_ARCH
 ARG KOKKOS_PRESET
@@ -170,7 +212,7 @@ RUN --mount=target=/cmake/presets/kokkos.json,type=bind,source=cmake/presets/kok
 EOF
 
 # Build the final image from previous stages.
-FROM requirements AS final
+FROM requirements-cmake AS final
 
 ARG DOXYGEN_VERSION
 ARG GOOGLEBENCHMARK_VERSION

--- a/include/kokkos-utils/callbacks/Helpers.hpp
+++ b/include/kokkos-utils/callbacks/Helpers.hpp
@@ -99,7 +99,7 @@ public:
 
 private:
     template <size_t Idx, typename IteratorType>
-    bool MatchAndExplainImpl(const IteratorType it_first, const IteratorType it_last, ::testing::MatchResultListener* const listener) const
+    bool MatchAndExplainImpl(const IteratorType& it_first, const IteratorType& it_last, ::testing::MatchResultListener* const listener) const
     {
         if (it_first == it_last) {;
             *listener << "does not contain in order an element that "
@@ -154,7 +154,7 @@ struct PartialMatcher;
 template <>
 struct PartialMatcher<AllocDescriptor>
 {
-    decltype(auto) operator()(AllocDescriptor descr) const {
+    decltype(auto) operator()(const AllocDescriptor& descr) const {
         return ::testing::AllOf(
             ::testing::Field(
                 &AllocDescriptor::kpsh,
@@ -162,7 +162,7 @@ struct PartialMatcher<AllocDescriptor>
             ),
             ::testing::Field(
                 &AllocDescriptor::name,
-                ::testing::StrEq(std::move(descr.name))
+                ::testing::StrEq(descr.name)
             ),
             ::testing::Field(
                 &AllocDescriptor::size,
@@ -180,10 +180,10 @@ struct PartialMatcher<AllocDescriptor>
 template <>
 struct PartialMatcher<BeginDeepCopyEvent>
 {
-    decltype(auto) operator()(BeginDeepCopyEvent event) const {
+    decltype(auto) operator()(const BeginDeepCopyEvent& event) const {
         return ::testing::AllOf(
-            ::testing::Field(&BeginDeepCopyEvent::dst, PartialMatcher<AllocDescriptor>{}(std::move(event.dst))),
-            ::testing::Field(&BeginDeepCopyEvent::src, PartialMatcher<AllocDescriptor>{}(std::move(event.src)))
+            ::testing::Field(&BeginDeepCopyEvent::dst, PartialMatcher<AllocDescriptor>{}(event.dst)),
+            ::testing::Field(&BeginDeepCopyEvent::src, PartialMatcher<AllocDescriptor>{}(event.src))
         );
     }
 };

--- a/include/kokkos-utils/callbacks/Manager.hpp
+++ b/include/kokkos-utils/callbacks/Manager.hpp
@@ -240,7 +240,7 @@ public:
     //! Dispatch the event to all registered listeners that can handle it.
     template <Event EventType>
     void dispatch(const EventType& event) const {
-        for (auto& listener: this->listeners) {
+        for (const auto& listener: this->listeners) {
             if (const auto* const callable = dynamic_cast<const impl::ListenerConceptCallOperator<EventType>*>(listener.get()); callable != nullptr) {
                 callable->operator()(event);
             }

--- a/include/kokkos-utils/callbacks/RecorderListener.hpp
+++ b/include/kokkos-utils/callbacks/RecorderListener.hpp
@@ -47,7 +47,7 @@ public:
     template <EventOneOf<EventTypes...> EventType>
     void operator()(const EventType& event) {
         if (matcher(event)) {
-            std::lock_guard lock(mtx);
+            const std::lock_guard lock(mtx);
             recorded_events.push_back(event);
         }
     }

--- a/include/kokkos-utils/callbacks/RegionTimerListener.hpp
+++ b/include/kokkos-utils/callbacks/RegionTimerListener.hpp
@@ -30,7 +30,7 @@ struct RegionTimerListener : public TimerListener<EventTypeMatcher<EventRegionMa
     using base_t           = TimerListener<matcher_t, timer_t>;
 
     template <typename T, typename U = TimerType>
-    RegionTimerListener(T&& matcher_, U&& timer_ = TimerType{}) : base_t{
+    explicit RegionTimerListener(T&& matcher_, U&& timer_ = TimerType{}) : base_t{
         matcher_t{matcher_t{.matcher = {.matcher = {std::forward<T>(matcher_)}}}},
         timer_t{std::forward<U>(timer_)}
     } {}


### PR DESCRIPTION
This PR allows to specify the version of the `clang` or `gcc` compiler we want to install.