### PR TITLE
Element at matcher

### DIFF
--- a/include/kokkos-utils/callbacks/Helpers.hpp
+++ b/include/kokkos-utils/callbacks/Helpers.hpp
@@ -136,11 +136,58 @@ private:
     std::tuple<Matchers...> matchers;
 };
 
+template <typename ElementType, typename ElementMatcher>
+class ElementAtMatcher
+{
+public:
+    explicit ElementAtMatcher(const size_t index, ElementMatcher matcher)
+        : m_index(index), m_matcher(std::move(matcher)) {}
+
+    template <typename IterableType>
+    bool MatchAndExplain(const IterableType& arg, ::testing::MatchResultListener* const listener) const
+    {
+        if (m_index >= arg.size()) {
+            *listener << "index " << m_index << " is out of bounds (size " << arg.size() << ")";
+            return false;
+        }
+        return ::testing::ExplainMatchResult(m_matcher, arg[m_index], listener);
+    }
+
+    void DescribeTo(std::ostream* out) const
+    {
+        *out << "element at index " << m_index << " "
+             << ::testing::DescribeMatcher<ElementType>(m_matcher, false);
+    }
+
+    void DescribeNegationTo(std::ostream* out) const
+    {
+        *out << "element at index " << m_index << " "
+             << ::testing::DescribeMatcher<ElementType>(m_matcher, true);
+    }
+
+private:
+    size_t m_index;
+    ElementMatcher m_matcher;
+};
+
 } // namespace impl
 
 template <typename T, typename... Matchers>
 auto ContainsInOrder(Matchers&&... matchers) {
     return ::testing::MakePolymorphicMatcher(impl::ContainsInOrderMatcher<T, std::remove_cvref_t<Matchers>...>(std::forward<Matchers>(matchers)...));
+}
+
+/**
+ * @brief Check that an element at a given index matches.
+ *
+ * @code
+ * ASSERT_THAT(iterable, ElementAt(index, matcher));
+ * @endcode
+ */
+template <typename ElementType, typename ElementMatcher>
+auto ElementAt(const size_t index, ElementMatcher&& matcher) {
+    return ::testing::MakePolymorphicMatcher(
+        impl::ElementAtMatcher<ElementType, std::remove_cvref_t<ElementMatcher>>{index, std::forward<ElementMatcher>(matcher)});
 }
 
 template <typename T>

--- a/tests/callbacks/test_Helpers.cpp
+++ b/tests/callbacks/test_Helpers.cpp
@@ -47,6 +47,28 @@ TEST(ContainsInOrderMatcher, Matches)
     ASSERT_THAT(vec, ::testing::Not(ContainsInOrder<int>(::testing::Eq(2), ::testing::Eq(1))));
 }
 
+//! @test Check that @ref Kokkos::utils::tests::callbacks::ElementAt can describe itself.
+TEST(ElementAtMatcher, CanDescribeItself)
+{
+    const auto matcher = ElementAt<int>(42, ::testing::Eq(666));
+    ASSERT_EQ(::testing::DescribeMatcher<std::vector<int>>(matcher), "element at index 42 is equal to 666");
+
+    const auto matcher_not = ::testing::Not(ElementAt<int>(42, ::testing::Eq(666)));
+    ASSERT_EQ(::testing::DescribeMatcher<std::vector<int>>(matcher_not), "element at index 42 isn't equal to 666");
+}
+
+//! @test Check that @ref Kokkos::utils::tests::callbacks::ElementAt matches as expected.
+TEST(ElementAtMatcher, Matches)
+{
+    const std::vector<int> vec{1, 2, 3, 4};
+    ASSERT_THAT(vec,                ElementAt<int>( 0, ::testing::Eq(1)));
+    ASSERT_THAT(vec,                ElementAt<int>( 1, ::testing::Eq(2)));
+    ASSERT_THAT(vec,                ElementAt<int>( 2, ::testing::Eq(3)));
+    ASSERT_THAT(vec,                ElementAt<int>( 3, ::testing::Eq(4)));
+    ASSERT_THAT(vec, ::testing::Not(ElementAt<int>( 0, ::testing::Eq(2))));
+    ASSERT_THAT(vec, ::testing::Not(ElementAt<int>(42, ::testing::Eq(2))));
+}
+
 //! @test Check that @ref Kokkos::utils::callbacks::PartialMatcher works as expected for @ref Kokkos::utils::callbacks::AllocDescriptor.
 TEST(PartialMatcher, AllocDescriptor)
 {


### PR DESCRIPTION
This PR introduces `ElementAt(index, matcher)` when we wish to match an element at a given index with some matcher and get a better message.

For example:
```c++
const std::vector<int> vec{1, 2, 3, 4};
ASSERT_THAT(vec, ElementAt<int>( 0, ::testing::Eq(23)));
```
will say:
```bash
[ RUN      ] ElementAtMatcher.Matches
/workspaces/kokkos-utils/tests/callbacks/test_Helpers.cpp:64: Failure
Value of: vec
Expected: element at index 0 is equal to 23
  Actual: { 1, 2, 3, 4 }
```

It will show the whole container of values, which is helpful when the element does not match and we wish to debug.