### PR TITLE
callbcaks(conjunction): allow default construction

### DIFF
--- a/include/kokkos-utils/callbacks/ConjunctionMatcher.hpp
+++ b/include/kokkos-utils/callbacks/ConjunctionMatcher.hpp
@@ -15,7 +15,9 @@ namespace Kokkos::utils::callbacks
 template <Matcher... MatcherTypes> requires (sizeof...(MatcherTypes) > 1)
 struct ConjunctionMatcher
 {
-    template <typename... Args> requires (sizeof...(Args) == sizeof...(MatcherTypes))
+    ConjunctionMatcher() = default;
+
+    template <typename... Args> requires (sizeof...(Args) > 0 && sizeof...(Args) == sizeof...(MatcherTypes))
     explicit ConjunctionMatcher(Args&&... args) : matchers(std::forward<Args>(args)...) {}
 
     template <Event EventType> requires (MatcherFor<MatcherTypes, EventType> && ...)
@@ -26,7 +28,7 @@ struct ConjunctionMatcher
         }, matchers);
     }
 
-    std::tuple<MatcherTypes...> matchers;
+    std::tuple<MatcherTypes...> matchers {};
 };
 
 template <typename... MatcherTypes>

--- a/tests/callbacks/test_Matchers.cpp
+++ b/tests/callbacks/test_Matchers.cpp
@@ -347,6 +347,14 @@ TEST(ConjunctionMatcher, different_event_type_sets)
     ASSERT_TRUE (matcher(BeginFenceEvent{.name = "my-triggering-event"}));
 }
 
+//! @test Check that @ref Kokkos::utils::callbacks::ConjunctionMatcher can be default constructed.
+TEST(ConjunctionMatcher, default_constructed)
+{
+    using matcher_t = ConjunctionMatcher<AnyEventMatcher, AnyEventMatcher>;
+
+    static_assert(std::default_initializable<matcher_t>);
+}
+
 //! Helper matcher that records in @ref encountered all the events passed to it.
 template <Matcher MatcherType>
 struct RecordingMatcher


### PR DESCRIPTION
It may be the conjunction of default-constructible matchers.

