### PR TITLE
tests(scoped): missing include `Kokkos_Core.hpp`

### DIFF
--- a/include/kokkos-utils/tests/scoped/ExecutionSpace.hpp
+++ b/include/kokkos-utils/tests/scoped/ExecutionSpace.hpp
@@ -1,6 +1,8 @@
 #ifndef KOKKOS_UTILS_TESTS_SCOPED_EXECUTIONSPACE_HPP
 #define KOKKOS_UTILS_TESTS_SCOPED_EXECUTIONSPACE_HPP
 
+#include "Kokkos_Core.hpp"
+
 namespace Kokkos::utils::tests::scoped
 {
 


### PR DESCRIPTION
This PR makes the header standalone.