### PR TITLE
Update: kokkos to 5.2(.99)

### DIFF
--- a/benchmarks/callbacks/CMakeLists.txt
+++ b/benchmarks/callbacks/CMakeLists.txt
@@ -4,6 +4,11 @@ target_sources(
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/benchmark_RegionTimer.cpp
 )
+target_include_directories(
+    benchmarks_callbacks_RegionTimer
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}
+)
 target_link_libraries(
     benchmarks_callbacks_RegionTimer
     PRIVATE

--- a/benchmarks/callbacks/benchmark_RegionTimer.cpp
+++ b/benchmarks/callbacks/benchmark_RegionTimer.cpp
@@ -1,5 +1,3 @@
-#include "benchmark/benchmark.h"
-
 #include "Kokkos_Core.hpp"
 
 #include "kokkos-utils/callbacks/EventNameMatcher.hpp"
@@ -7,6 +5,8 @@
 #include "kokkos-utils/callbacks/SequenceOfRegionTimerListener.hpp"
 
 #include "kokkos-utils/tests/scoped/callbacks/Manager.hpp"
+
+#include "tests/Benchmarking.hpp"
 
 /**
  * @addtogroup unitbenchmarks
@@ -94,6 +94,9 @@ public:
     using impl_t = T;
 
 public:
+    FIXME_PARTIAL_OVERRIDE_WARNING_NVCC(TearDown)
+    FIXME_PARTIAL_OVERRIDE_WARNING_NVCC(SetUp)
+
     void SetUp(const ::benchmark::State& state) override {
         impl.emplace(state);
     }

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -43,7 +43,17 @@ RUN <<EOF
     g++ -dumpfullversion -dumpversion
 EOF
 
+COPY <<EOF /opt/toolchain.cmake
+set(CMAKE_C_COMPILER /usr/bin/gcc)
+set(CMAKE_CXX_COMPILER /usr/bin/g++)
+EOF
+
 FROM requirements-python AS requirements-compiler-rocm
+
+COPY <<EOF /opt/toolchain.cmake
+set(CMAKE_C_COMPILER /usr/bin/amdclang)
+set(CMAKE_CXX_COMPILER /usr/bin/amdclang++)
+EOF
 
 FROM requirements-python AS requirements-compiler-clang
 
@@ -71,6 +81,11 @@ RUN <<EOF
         clang++=clang++-${COMPILER_VERSION}                  \
         clang-tidy=clang-tidy-${COMPILER_VERSION}            \
         clang-format=clang-format-${COMPILER_VERSION}
+EOF
+
+COPY <<EOF /opt/toolchain.cmake
+set(CMAKE_C_COMPILER /usr/bin/clang)
+set(CMAKE_CXX_COMPILER /usr/bin/clang++)
 EOF
 
 FROM requirements-compiler-${COMPILER_FAMILY} AS requirements-system
@@ -126,6 +141,7 @@ RUN <<EOF
     cd doxygen
 
     cmake -S . -B build \
+        --toolchain /opt/toolchain.cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/opt/doxygen-${DOXYGEN_VERSION}
 
@@ -145,6 +161,7 @@ RUN <<EOF
     cd googletest
 
     cmake -S . -B build \
+        --toolchain /opt/toolchain.cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/opt/google-test-${GOOGLETEST_VERSION}
 
@@ -168,6 +185,7 @@ RUN <<EOF
     git checkout f649efee480295b01a04bf077cdd50b3293d56c5
 
     cmake -S . -B build \
+        --toolchain /opt/toolchain.cmake \
         -DCMAKE_INSTALL_PREFIX=/opt/google-benchmark-${GOOGLEBENCHMARK_VERSION} \
         -DCMAKE_BUILD_TYPE=Release \
         -DBENCHMARK_ENABLE_TESTING=OFF \

--- a/include/kokkos-utils/callbacks/Helpers.hpp
+++ b/include/kokkos-utils/callbacks/Helpers.hpp
@@ -102,8 +102,10 @@ private:
     bool MatchAndExplainImpl(const IteratorType& it_first, const IteratorType& it_last, ::testing::MatchResultListener* const listener) const
     {
         if (it_first == it_last) {;
-            *listener << "does not contain in order an element that "
-                      << ::testing::DescribeMatcher<T>(std::get<Idx>(matchers), false);
+            if (listener->IsInterested()) {
+                *listener->stream() << "does not contain in order an element that "
+                                    << ::testing::DescribeMatcher<T>(std::get<Idx>(matchers), false);
+            }
             return false;
         }
 
@@ -147,8 +149,10 @@ public:
     bool MatchAndExplain(const IterableType& arg, ::testing::MatchResultListener* const listener) const
     {
         if (m_index >= arg.size()) {
-            *listener << "index " << m_index << " is out of bounds (size " << arg.size() << ")";
-            return false;
+            if (listener->IsInterested()) {
+                *listener->stream() << "index " << m_index << " is out of bounds (size " << arg.size() << ")";
+                return false;
+            }
         }
         return ::testing::ExplainMatchResult(m_matcher, arg[m_index], listener);
     }

--- a/tests/Benchmarking.hpp
+++ b/tests/Benchmarking.hpp
@@ -1,0 +1,17 @@
+#ifndef KOKKOS_UTILS_TESTS_BENCHMARKING_HPP
+#define KOKKOS_UTILS_TESTS_BENCHMARKING_HPP
+
+#include "benchmark/benchmark.h"
+
+//! These partial overrides are only needed by 'nvcc' (as of @c Cuda 12.8.0).
+#if defined(__NVCC__)
+//! Use this macro when only one @c __what__ method is overridden.
+#    define FIXME_PARTIAL_OVERRIDE_WARNING_NVCC(__what__)                                                              \
+        void __what__(::benchmark::State& state) override {                                                            \
+            this->__what__(static_cast<const ::benchmark::State&>(state));                                             \
+        }
+#else
+#    define FIXME_PARTIAL_OVERRIDE_WARNING_NVCC(...)
+#endif
+
+#endif // KOKKOS_UTILS_TESTS_BENCHMARKING_HPP

--- a/version.json
+++ b/version.json
@@ -4,20 +4,20 @@
     },
     "dependencies" : {
         "cmake" : {
-            "value" : "4.2.1"
+            "value" : "4.4.2"
         },
         "doxygen" : {
-            "value" : "1.13.2"
+            "value" : "1.18.0"
         },
         "googlebenchmark" : {
             "value" : "1.9.5"
         },
         "googletest" : {
-            "value" : "1.17.0"
+            "value" : "1.18.0"
         },
         "kokkos" : {
-            "value" : "5.1.99",
-            "sha"   : "1a270d792150b24bf28d085d4007e5d3851759bf"
+            "value" : "5.2.99",
+            "sha"   : "e511cd4f64f6d77a3b3a24933b87073bfc397820"
         }
     }
 }


### PR DESCRIPTION
Drive-by:
- update cmake, google test and doxygen.

Bigger issue seen when working on the drive-by, and `doxygen` failed to compile in the clang builds, and it seems the underlying issue is that we don't specify the C/CXX compilers when we compile doxygen, google test, ... And so CMake looks for them. In the case of the clang builds, it finds gcc for the C compiler and clang++ for the C++ compiler. As a solution, this PR proposes to use a `toolchain.cmake` file to set the two compilers. The alternatives are setting environment variables (but we already have the presets for Kokkos) or adding build arguments from the workflow file.