### PR TITLE
CICD: update gcc build to 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
                     - backend        : OpenMP
                       compiler:
                         family: gcc
-                        version: 15
+                        version: 16
                       base_image     : ubuntu:26.04
                       platforms      : linux/amd64
                       tag_suffix     : -amd64
@@ -167,7 +167,7 @@ jobs:
                     - backend        : OpenMP
                       compiler:
                         family: gcc
-                        version: 15
+                        version: 16
                       base_image     : ubuntu:26.04
                       platforms      : linux/arm64
                       runs-on        : ubuntu-24.04-arm
@@ -253,7 +253,7 @@ jobs:
                     - backend: OpenMP
                       compiler:
                         family: gcc
-                        version: 15
+                        version: 16
         steps:
             - uses: docker/login-action@v4
               with:
@@ -306,13 +306,13 @@ jobs:
                     - backend        : OpenMP
                       compiler:
                         family: gcc
-                        version: 15
+                        version: 16
                       runs-on        : ubuntu-24.04
                       platform       : linux/amd64
                     - backend        : OpenMP
                       compiler:
                         family: gcc
-                        version: 15
+                        version: 16
                       runs-on        : ubuntu-24.04-arm
                       platform       : linux/arm64
                     - backend        : OpenMP
@@ -360,7 +360,7 @@ jobs:
         if: ${{ ! failure() && ! cancelled() }}
         runs-on: [ubuntu-latest]
         container:
-            image: ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:gcc-15-OpenMP
+            image: ${{ needs.set-vars-and-skips.outputs.CI_IMAGE }}:gcc-16-OpenMP
         steps:
             - uses: actions/checkout@v7
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -57,7 +57,7 @@
         },
         {
             "name"           : "gcc-OpenMP",
-            "inherits"       : ["gcc", "default"],
+            "inherits"       : ["gcc", "cxx23", "default"],
             "cacheVariables" : {
                 "EXPECTED_Kokkos_DEVICES" : "SERIAL;OPENMP"
             }

--- a/cmake/presets/kokkos.json
+++ b/cmake/presets/kokkos.json
@@ -41,6 +41,12 @@
             "cacheVariables" : {"CMAKE_CXX_COMPILER" : "hipcc"}
         },
         {
+            "$comment": "Inherit from this preset to use C++23.",
+            "name" : "cxx23",
+            "hidden" : true,
+            "cacheVariables" : {"CMAKE_CXX_STANDARD": "23"}
+        },
+        {
             "$comment": "Inherit from this preset to use the OpenMP backend.",
             "name"           : "OpenMP",
             "hidden"         : true,
@@ -85,11 +91,11 @@
         },
         {
             "name"     : "gcc-OpenMP",
-            "inherits" : ["OpenMP", "gcc", "default"]
+            "inherits" : ["OpenMP", "gcc", "cxx23", "default"]
         },
         {
             "name"     : "clang-OpenMP",
-            "inherits" : ["OpenMP", "clang", "default"]
+            "inherits" : ["OpenMP", "clang", "cxx23", "default"]
         },
         {
             "name"     : "gcc-Cuda",


### PR DESCRIPTION
Drive-by:
- update gcc-OpenMP builds to C++23
- for builds that compile with C++23, update the underlying builds of Kokkos to C++23 too 